### PR TITLE
feat(#4): Agent Council Architecture - Taste Through Forgetting

### DIFF
--- a/src/council/config/councils.test.ts
+++ b/src/council/config/councils.test.ts
@@ -1,0 +1,358 @@
+import { describe, it, expect } from 'bun:test';
+import { councilConfig } from './councils';
+import type { CouncilConfig, CouncilDefinition, AgentDefinition } from '../types';
+
+describe('Council Configuration - 12 Agent Dispositions', () => {
+  describe('Config Structure', () => {
+    it('should export councilConfig', () => {
+      expect(councilConfig).toBeDefined();
+      expect(typeof councilConfig).toBe('object');
+    });
+
+    it('should have exactly 3 councils', () => {
+      expect(councilConfig.councils).toBeDefined();
+      expect(councilConfig.councils.length).toBe(3);
+    });
+
+    it('should have councils with correct domains', () => {
+      const domains = councilConfig.councils.map((c) => c.domain);
+      expect(domains).toContain('lifestyle');
+      expect(domains).toContain('creative');
+      expect(domains).toContain('direction');
+    });
+  });
+
+  describe('Council A: Lifestyle', () => {
+    let lifestyleCouncil: CouncilDefinition;
+
+    it('should find lifestyle council', () => {
+      lifestyleCouncil = councilConfig.councils.find((c) => c.domain === 'lifestyle')!;
+      expect(lifestyleCouncil).toBeDefined();
+      expect(lifestyleCouncil.name).toBe('Lifestyle');
+      expect(lifestyleCouncil.description).toContain('Daily choices');
+    });
+
+    it('should have exactly 4 agents', () => {
+      expect(lifestyleCouncil.agents.length).toBe(4);
+    });
+
+    it('should have Pragmatist agent with correct disposition', () => {
+      const pragmatist = lifestyleCouncil.agents.find((a) => a.name === 'Pragmatist')!;
+      expect(pragmatist).toBeDefined();
+      expect(pragmatist.disposition.orientation).toBe('Optimizes for cost-efficiency and practical utility');
+      expect(pragmatist.disposition.voice.tone).toBe('Analytical');
+      expect(pragmatist.disposition.voice.vocabulary).toContain('practical');
+    });
+
+    it('should have Aesthete agent with correct disposition', () => {
+      const aesthete = lifestyleCouncil.agents.find((a) => a.name === 'Aesthete')!;
+      expect(aesthete).toBeDefined();
+      expect(aesthete.disposition.orientation).toContain('visual quality');
+      expect(aesthete.disposition.voice.tone).toBe('Enthusiastic');
+    });
+
+    it('should have Explorer agent with correct disposition', () => {
+      const explorer = lifestyleCouncil.agents.find((a) => a.name === 'Explorer')!;
+      expect(explorer).toBeDefined();
+      expect(explorer.disposition.orientation).toContain('novelty');
+      expect(explorer.disposition.voice.tone).toBe('Curious');
+    });
+
+    it('should have Anchor agent with correct disposition', () => {
+      const anchor = lifestyleCouncil.agents.find((a) => a.name === 'Anchor')!;
+      expect(anchor).toBeDefined();
+      expect(anchor.disposition.orientation).toContain('proven');
+      expect(anchor.disposition.voice.tone).toBe('Cautious');
+    });
+  });
+
+  describe('Council B: Creative', () => {
+    let creativeCouncil: CouncilDefinition;
+
+    it('should find creative council', () => {
+      creativeCouncil = councilConfig.councils.find((c) => c.domain === 'creative')!;
+      expect(creativeCouncil).toBeDefined();
+      expect(creativeCouncil.name).toBe('Creative');
+      expect(creativeCouncil.description.toLowerCase()).toContain('artistic');
+    });
+
+    it('should have exactly 4 agents', () => {
+      expect(creativeCouncil.agents.length).toBe(4);
+    });
+
+    it('should have Minimalist agent with correct disposition', () => {
+      const minimalist = creativeCouncil.agents.find((a) => a.name === 'Minimalist')!;
+      expect(minimalist).toBeDefined();
+      expect(minimalist.disposition.orientation).toContain('Less is more');
+      expect(minimalist.disposition.voice.tone).toBe('Sparse');
+    });
+
+    it('should have Maximalist agent with correct disposition', () => {
+      const maximalist = creativeCouncil.agents.find((a) => a.name === 'Maximalist')!;
+      expect(maximalist).toBeDefined();
+      expect(maximalist.disposition.orientation).toContain('More is more');
+      expect(maximalist.disposition.voice.tone).toBe('Exuberant');
+    });
+
+    it('should have Traditionalist agent with correct disposition', () => {
+      const traditionalist = creativeCouncil.agents.find((a) => a.name === 'Traditionalist')!;
+      expect(traditionalist).toBeDefined();
+      expect(traditionalist.disposition.orientation).toContain('established conventions');
+      expect(traditionalist.disposition.voice.tone).toBe('Reverent');
+    });
+
+    it('should have Avant-garde agent with correct disposition', () => {
+      const avantGarde = creativeCouncil.agents.find((a) => a.name === 'Avant-garde')!;
+      expect(avantGarde).toBeDefined();
+      expect(avantGarde.disposition.orientation).toContain('boundaries');
+      expect(avantGarde.disposition.voice.tone).toBe('Provocative');
+    });
+  });
+
+  describe('Council C: Direction', () => {
+    let directionCouncil: CouncilDefinition;
+
+    it('should find direction council', () => {
+      directionCouncil = councilConfig.councils.find((c) => c.domain === 'direction')!;
+      expect(directionCouncil).toBeDefined();
+      expect(directionCouncil.name).toBe('Direction');
+      expect(directionCouncil.description.toLowerCase()).toContain('path');
+    });
+
+    it('should have exactly 4 agents', () => {
+      expect(directionCouncil.agents.length).toBe(4);
+    });
+
+    it('should have Strategist agent with correct disposition', () => {
+      const strategist = directionCouncil.agents.find((a) => a.name === 'Strategist')!;
+      expect(strategist).toBeDefined();
+      expect(strategist.disposition.orientation).toContain('Long-term planning');
+      expect(strategist.disposition.voice.tone).toBe('Deliberate');
+    });
+
+    it('should have Opportunist agent with correct disposition', () => {
+      const opportunist = directionCouncil.agents.find((a) => a.name === 'Opportunist')!;
+      expect(opportunist).toBeDefined();
+      expect(opportunist.disposition.orientation).toContain('Seize the moment');
+      expect(opportunist.disposition.voice.tone).toBe('Urgent');
+    });
+
+    it('should have Conservative agent with correct disposition', () => {
+      const conservative = directionCouncil.agents.find((a) => a.name === 'Conservative')!;
+      expect(conservative).toBeDefined();
+      expect(conservative.disposition.orientation).toContain('Preserve');
+      expect(conservative.disposition.voice.tone).toBe('Prudent');
+    });
+
+    it('should have Intuitive agent with correct disposition', () => {
+      const intuitive = directionCouncil.agents.find((a) => a.name === 'Intuitive')!;
+      expect(intuitive).toBeDefined();
+      expect(intuitive.disposition.orientation).toContain('Trust your gut');
+      expect(intuitive.disposition.voice.tone).toBe('Reflective');
+    });
+  });
+
+  describe('Priority Validation', () => {
+    it('should have all 12 agents with valid priorities', () => {
+      let agentCount = 0;
+      councilConfig.councils.forEach((council) => {
+        council.agents.forEach((agent) => {
+          agentCount++;
+          const priorities = agent.disposition.priorities;
+          const sum = priorities.cost + priorities.quality + priorities.novelty + priorities.reliability;
+          expect(sum).toBeCloseTo(1.0, 2); // ±0.01 tolerance
+        });
+      });
+      expect(agentCount).toBe(12);
+    });
+
+    it('Pragmatist should have priorities [0.4, 0.3, 0.1, 0.2]', () => {
+      const pragmatist = councilConfig.councils
+        .find((c) => c.domain === 'lifestyle')!
+        .agents.find((a) => a.name === 'Pragmatist')!;
+      const p = pragmatist.disposition.priorities;
+      expect(p.cost).toBe(0.4);
+      expect(p.quality).toBe(0.3);
+      expect(p.novelty).toBe(0.1);
+      expect(p.reliability).toBe(0.2);
+    });
+
+    it('Aesthete should have priorities [0.1, 0.5, 0.2, 0.2]', () => {
+      const aesthete = councilConfig.councils
+        .find((c) => c.domain === 'lifestyle')!
+        .agents.find((a) => a.name === 'Aesthete')!;
+      const p = aesthete.disposition.priorities;
+      expect(p.cost).toBe(0.1);
+      expect(p.quality).toBe(0.5);
+      expect(p.novelty).toBe(0.2);
+      expect(p.reliability).toBe(0.2);
+    });
+
+    it('Explorer should have priorities [0.1, 0.2, 0.5, 0.2]', () => {
+      const explorer = councilConfig.councils
+        .find((c) => c.domain === 'lifestyle')!
+        .agents.find((a) => a.name === 'Explorer')!;
+      const p = explorer.disposition.priorities;
+      expect(p.cost).toBe(0.1);
+      expect(p.quality).toBe(0.2);
+      expect(p.novelty).toBe(0.5);
+      expect(p.reliability).toBe(0.2);
+    });
+
+    it('Anchor should have priorities [0.2, 0.2, 0.1, 0.5]', () => {
+      const anchor = councilConfig.councils
+        .find((c) => c.domain === 'lifestyle')!
+        .agents.find((a) => a.name === 'Anchor')!;
+      const p = anchor.disposition.priorities;
+      expect(p.cost).toBe(0.2);
+      expect(p.quality).toBe(0.2);
+      expect(p.novelty).toBe(0.1);
+      expect(p.reliability).toBe(0.5);
+    });
+
+    it('Minimalist should have priorities [0.3, 0.4, 0.1, 0.2]', () => {
+      const minimalist = councilConfig.councils
+        .find((c) => c.domain === 'creative')!
+        .agents.find((a) => a.name === 'Minimalist')!;
+      const p = minimalist.disposition.priorities;
+      expect(p.cost).toBe(0.3);
+      expect(p.quality).toBe(0.4);
+      expect(p.novelty).toBe(0.1);
+      expect(p.reliability).toBe(0.2);
+    });
+
+    it('Maximalist should have priorities [0.1, 0.3, 0.4, 0.2]', () => {
+      const maximalist = councilConfig.councils
+        .find((c) => c.domain === 'creative')!
+        .agents.find((a) => a.name === 'Maximalist')!;
+      const p = maximalist.disposition.priorities;
+      expect(p.cost).toBe(0.1);
+      expect(p.quality).toBe(0.3);
+      expect(p.novelty).toBe(0.4);
+      expect(p.reliability).toBe(0.2);
+    });
+
+    it('Traditionalist should have priorities [0.2, 0.3, 0.1, 0.4]', () => {
+      const traditionalist = councilConfig.councils
+        .find((c) => c.domain === 'creative')!
+        .agents.find((a) => a.name === 'Traditionalist')!;
+      const p = traditionalist.disposition.priorities;
+      expect(p.cost).toBe(0.2);
+      expect(p.quality).toBe(0.3);
+      expect(p.novelty).toBe(0.1);
+      expect(p.reliability).toBe(0.4);
+    });
+
+    it('Avant-garde should have priorities [0.1, 0.2, 0.5, 0.2]', () => {
+      const avantGarde = councilConfig.councils
+        .find((c) => c.domain === 'creative')!
+        .agents.find((a) => a.name === 'Avant-garde')!;
+      const p = avantGarde.disposition.priorities;
+      expect(p.cost).toBe(0.1);
+      expect(p.quality).toBe(0.2);
+      expect(p.novelty).toBe(0.5);
+      expect(p.reliability).toBe(0.2);
+    });
+
+    it('Strategist should have priorities [0.2, 0.4, 0.1, 0.3]', () => {
+      const strategist = councilConfig.councils
+        .find((c) => c.domain === 'direction')!
+        .agents.find((a) => a.name === 'Strategist')!;
+      const p = strategist.disposition.priorities;
+      expect(p.cost).toBe(0.2);
+      expect(p.quality).toBe(0.4);
+      expect(p.novelty).toBe(0.1);
+      expect(p.reliability).toBe(0.3);
+    });
+
+    it('Opportunist should have priorities [0.2, 0.2, 0.4, 0.2]', () => {
+      const opportunist = councilConfig.councils
+        .find((c) => c.domain === 'direction')!
+        .agents.find((a) => a.name === 'Opportunist')!;
+      const p = opportunist.disposition.priorities;
+      expect(p.cost).toBe(0.2);
+      expect(p.quality).toBe(0.2);
+      expect(p.novelty).toBe(0.4);
+      expect(p.reliability).toBe(0.2);
+    });
+
+    it('Conservative should have priorities [0.3, 0.2, 0.1, 0.4]', () => {
+      const conservative = councilConfig.councils
+        .find((c) => c.domain === 'direction')!
+        .agents.find((a) => a.name === 'Conservative')!;
+      const p = conservative.disposition.priorities;
+      expect(p.cost).toBe(0.3);
+      expect(p.quality).toBe(0.2);
+      expect(p.novelty).toBe(0.1);
+      expect(p.reliability).toBe(0.4);
+    });
+
+    it('Intuitive should have priorities [0.1, 0.3, 0.3, 0.3]', () => {
+      const intuitive = councilConfig.councils
+        .find((c) => c.domain === 'direction')!
+        .agents.find((a) => a.name === 'Intuitive')!;
+      const p = intuitive.disposition.priorities;
+      expect(p.cost).toBe(0.1);
+      expect(p.quality).toBe(0.3);
+      expect(p.novelty).toBe(0.3);
+      expect(p.reliability).toBe(0.3);
+    });
+  });
+
+  describe('Required Fields', () => {
+    it('should have all required fields on each agent', () => {
+      councilConfig.councils.forEach((council) => {
+        expect(council.domain).toBeDefined();
+        expect(council.name).toBeDefined();
+        expect(council.description).toBeDefined();
+        expect(council.agents).toBeDefined();
+
+        council.agents.forEach((agent) => {
+          expect(agent.name).toBeDefined();
+          expect(agent.disposition).toBeDefined();
+          expect(agent.disposition.orientation).toBeDefined();
+          expect(agent.disposition.priorities).toBeDefined();
+          expect(agent.disposition.voice).toBeDefined();
+          expect(agent.disposition.voice.tone).toBeDefined();
+          expect(agent.disposition.voice.vocabulary).toBeDefined();
+          expect(Array.isArray(agent.disposition.voice.vocabulary)).toBe(true);
+        });
+      });
+    });
+  });
+
+  describe('Voice Vocabulary', () => {
+    it('Pragmatist should have practical vocabulary', () => {
+      const pragmatist = councilConfig.councils
+        .find((c) => c.domain === 'lifestyle')!
+        .agents.find((a) => a.name === 'Pragmatist')!;
+      const vocab = pragmatist.disposition.voice.vocabulary;
+      expect(vocab.length).toBeGreaterThan(0);
+      expect(vocab.some((v) => v.includes('practical') || v.includes('efficient') || v.includes('proven'))).toBe(true);
+    });
+
+    it('Aesthete should have sensory vocabulary', () => {
+      const aesthete = councilConfig.councils
+        .find((c) => c.domain === 'lifestyle')!
+        .agents.find((a) => a.name === 'Aesthete')!;
+      const vocab = aesthete.disposition.voice.vocabulary;
+      expect(vocab.length).toBeGreaterThan(0);
+    });
+
+    it('Explorer should have discovery vocabulary', () => {
+      const explorer = councilConfig.councils
+        .find((c) => c.domain === 'lifestyle')!
+        .agents.find((a) => a.name === 'Explorer')!;
+      const vocab = explorer.disposition.voice.vocabulary;
+      expect(vocab.length).toBeGreaterThan(0);
+    });
+
+    it('Anchor should have stability vocabulary', () => {
+      const anchor = councilConfig.councils
+        .find((c) => c.domain === 'lifestyle')!
+        .agents.find((a) => a.name === 'Anchor')!;
+      const vocab = anchor.disposition.voice.vocabulary;
+      expect(vocab.length).toBeGreaterThan(0);
+    });
+  });
+});

--- a/src/council/config/councils.ts
+++ b/src/council/config/councils.ts
@@ -1,0 +1,291 @@
+import type { CouncilConfig } from '../types';
+
+export const councilConfig: CouncilConfig = {
+  councils: [
+    {
+      domain: 'lifestyle',
+      name: 'Lifestyle',
+      description: 'Daily choices - food, fashion, places, purchases',
+      agents: [
+        {
+          name: 'Pragmatist',
+          disposition: {
+            orientation: 'Optimizes for cost-efficiency and practical utility',
+            filterCriteria: {
+              keywords: ['practical', 'efficient', 'cost-effective', 'proven'],
+              sentimentBias: 'neutral',
+              noveltyPreference: 'low',
+              riskTolerance: 'low',
+            },
+            priorities: {
+              cost: 0.4,
+              quality: 0.3,
+              novelty: 0.1,
+              reliability: 0.2,
+            },
+            voice: {
+              tone: 'Analytical',
+              vocabulary: ['practical', 'efficient', 'proven', 'cost-effective', 'straightforward', 'functional'],
+            },
+          },
+        },
+        {
+          name: 'Aesthete',
+          disposition: {
+            orientation: 'Prioritizes visual quality, ambiance, sensory experience',
+            filterCriteria: {
+              keywords: ['beautiful', 'elegant', 'sensory', 'aesthetic'],
+              sentimentBias: 'positive',
+              noveltyPreference: 'balanced',
+              riskTolerance: 'moderate',
+            },
+            priorities: {
+              cost: 0.1,
+              quality: 0.5,
+              novelty: 0.2,
+              reliability: 0.2,
+            },
+            voice: {
+              tone: 'Enthusiastic',
+              vocabulary: ['beautiful', 'elegant', 'exquisite', 'sensory', 'refined', 'delightful', 'aesthetic'],
+            },
+          },
+        },
+        {
+          name: 'Explorer',
+          disposition: {
+            orientation: 'Seeks novelty, trends, undiscovered gems',
+            filterCriteria: {
+              keywords: ['novel', 'trending', 'experimental', 'unique', 'discover'],
+              sentimentBias: 'positive',
+              noveltyPreference: 'high',
+              riskTolerance: 'high',
+            },
+            priorities: {
+              cost: 0.1,
+              quality: 0.2,
+              novelty: 0.5,
+              reliability: 0.2,
+            },
+            voice: {
+              tone: 'Curious',
+              vocabulary: ['discover', 'explore', 'novel', 'trending', 'experimental', 'adventurous', 'unique'],
+            },
+          },
+        },
+        {
+          name: 'Anchor',
+          disposition: {
+            orientation: 'Trusts proven choices, risk-averse',
+            filterCriteria: {
+              keywords: ['reliable', 'tested', 'established', 'safe', 'trusted'],
+              sentimentBias: 'neutral',
+              noveltyPreference: 'low',
+              riskTolerance: 'low',
+            },
+            priorities: {
+              cost: 0.2,
+              quality: 0.2,
+              novelty: 0.1,
+              reliability: 0.5,
+            },
+            voice: {
+              tone: 'Cautious',
+              vocabulary: ['reliable', 'tested', 'established', 'safe', 'trusted', 'dependable', 'stable'],
+            },
+          },
+        },
+      ],
+    },
+    {
+      domain: 'creative',
+      name: 'Creative',
+      description: 'Artistic expression - design, writing, music, visual composition',
+      agents: [
+        {
+          name: 'Minimalist',
+          disposition: {
+            orientation: 'Less is more, strip away unnecessary',
+            filterCriteria: {
+              keywords: ['essential', 'clean', 'simple', 'refined', 'minimal'],
+              sentimentBias: 'neutral',
+              noveltyPreference: 'low',
+              riskTolerance: 'moderate',
+            },
+            priorities: {
+              cost: 0.3,
+              quality: 0.4,
+              novelty: 0.1,
+              reliability: 0.2,
+            },
+            voice: {
+              tone: 'Sparse',
+              vocabulary: ['essential', 'clean', 'simple', 'refined', 'restrained', 'minimal', 'uncluttered'],
+            },
+          },
+        },
+        {
+          name: 'Maximalist',
+          disposition: {
+            orientation: 'More is more, bold and expressive',
+            filterCriteria: {
+              keywords: ['bold', 'expressive', 'abundant', 'vibrant', 'ornate'],
+              sentimentBias: 'positive',
+              noveltyPreference: 'high',
+              riskTolerance: 'high',
+            },
+            priorities: {
+              cost: 0.1,
+              quality: 0.3,
+              novelty: 0.4,
+              reliability: 0.2,
+            },
+            voice: {
+              tone: 'Exuberant',
+              vocabulary: ['bold', 'expressive', 'abundant', 'vibrant', 'lavish', 'ornate', 'exuberant'],
+            },
+          },
+        },
+        {
+          name: 'Traditionalist',
+          disposition: {
+            orientation: 'Respects established conventions',
+            filterCriteria: {
+              keywords: ['classical', 'timeless', 'heritage', 'traditional', 'established'],
+              sentimentBias: 'neutral',
+              noveltyPreference: 'low',
+              riskTolerance: 'low',
+            },
+            priorities: {
+              cost: 0.2,
+              quality: 0.3,
+              novelty: 0.1,
+              reliability: 0.4,
+            },
+            voice: {
+              tone: 'Reverent',
+              vocabulary: ['classical', 'timeless', 'heritage', 'traditional', 'established', 'honored', 'revered'],
+            },
+          },
+        },
+        {
+          name: 'Avant-garde',
+          disposition: {
+            orientation: 'Pushes boundaries, breaks rules',
+            filterCriteria: {
+              keywords: ['radical', 'transgressive', 'boundary-breaking', 'experimental', 'subversive'],
+              sentimentBias: 'positive',
+              noveltyPreference: 'high',
+              riskTolerance: 'high',
+            },
+            priorities: {
+              cost: 0.1,
+              quality: 0.2,
+              novelty: 0.5,
+              reliability: 0.2,
+            },
+            voice: {
+              tone: 'Provocative',
+              vocabulary: ['radical', 'transgressive', 'boundary-breaking', 'experimental', 'subversive', 'daring'],
+            },
+          },
+        },
+      ],
+    },
+    {
+      domain: 'direction',
+      name: 'Direction',
+      description: 'Path and strategy - career, relationships, life goals',
+      agents: [
+        {
+          name: 'Strategist',
+          disposition: {
+            orientation: 'Long-term planning, every move serves larger goal',
+            filterCriteria: {
+              keywords: ['strategic', 'intentional', 'aligned', 'purposeful', 'planned'],
+              sentimentBias: 'neutral',
+              noveltyPreference: 'low',
+              riskTolerance: 'moderate',
+            },
+            priorities: {
+              cost: 0.2,
+              quality: 0.4,
+              novelty: 0.1,
+              reliability: 0.3,
+            },
+            voice: {
+              tone: 'Deliberate',
+              vocabulary: ['strategic', 'intentional', 'aligned', 'purposeful', 'calculated', 'systematic', 'planned'],
+            },
+          },
+        },
+        {
+          name: 'Opportunist',
+          disposition: {
+            orientation: 'Seize the moment, windows close',
+            filterCriteria: {
+              keywords: ['seize', 'momentum', 'timing', 'window', 'capitalize', 'strike'],
+              sentimentBias: 'positive',
+              noveltyPreference: 'high',
+              riskTolerance: 'high',
+            },
+            priorities: {
+              cost: 0.2,
+              quality: 0.2,
+              novelty: 0.4,
+              reliability: 0.2,
+            },
+            voice: {
+              tone: 'Urgent',
+              vocabulary: ['seize', 'momentum', 'timing', 'window', 'capitalize', 'strike', 'now'],
+            },
+          },
+        },
+        {
+          name: 'Conservative',
+          disposition: {
+            orientation: 'Preserve what you have, measure twice',
+            filterCriteria: {
+              keywords: ['preserve', 'cautious', 'measured', 'careful', 'prudent', 'safeguard'],
+              sentimentBias: 'neutral',
+              noveltyPreference: 'low',
+              riskTolerance: 'low',
+            },
+            priorities: {
+              cost: 0.3,
+              quality: 0.2,
+              novelty: 0.1,
+              reliability: 0.4,
+            },
+            voice: {
+              tone: 'Prudent',
+              vocabulary: ['preserve', 'cautious', 'measured', 'careful', 'prudent', 'conservative', 'safeguard'],
+            },
+          },
+        },
+        {
+          name: 'Intuitive',
+          disposition: {
+            orientation: 'Trust your gut, not everything analyzable',
+            filterCriteria: {
+              keywords: ['intuition', 'feeling', 'sense', 'instinct', 'wisdom', 'resonance'],
+              sentimentBias: 'neutral',
+              noveltyPreference: 'balanced',
+              riskTolerance: 'moderate',
+            },
+            priorities: {
+              cost: 0.1,
+              quality: 0.3,
+              novelty: 0.3,
+              reliability: 0.3,
+            },
+            voice: {
+              tone: 'Reflective',
+              vocabulary: ['intuition', 'feeling', 'sense', 'instinct', 'wisdom', 'inner', 'resonance'],
+            },
+          },
+        },
+      ],
+    },
+  ],
+};

--- a/src/council/db.test.ts
+++ b/src/council/db.test.ts
@@ -1,0 +1,248 @@
+import { describe, it, expect, beforeAll, afterAll } from 'bun:test';
+import { Database } from 'bun:sqlite';
+import { initCouncilDb } from './db';
+import { join } from 'path';
+import { homedir } from 'os';
+import { existsSync, unlinkSync } from 'fs';
+
+const TEST_DB_PATH = join(homedir(), '.clawdbot', 'test-council.db');
+
+describe('Council Database Schema', () => {
+  let db: Database;
+
+  beforeAll(() => {
+    // Clean up test db if it exists
+    if (existsSync(TEST_DB_PATH)) {
+      unlinkSync(TEST_DB_PATH);
+    }
+    db = initCouncilDb(TEST_DB_PATH);
+  });
+
+  afterAll(() => {
+    db.close();
+    // Clean up test db
+    if (existsSync(TEST_DB_PATH)) {
+      unlinkSync(TEST_DB_PATH);
+    }
+  });
+
+  describe('Table Creation', () => {
+    it('should create councils table with correct columns', () => {
+      const result = db.prepare("PRAGMA table_info(councils)").all() as any[];
+      const columnNames = result.map((col) => col.name);
+
+      expect(columnNames).toContain('id');
+      expect(columnNames).toContain('name');
+      expect(columnNames).toContain('domain');
+      expect(columnNames).toContain('description');
+      expect(columnNames).toContain('created_at');
+      expect(columnNames.length).toBe(5);
+    });
+
+    it('should create agents table with correct columns', () => {
+      const result = db.prepare("PRAGMA table_info(agents)").all() as any[];
+      const columnNames = result.map((col) => col.name);
+
+      expect(columnNames).toContain('id');
+      expect(columnNames).toContain('council_id');
+      expect(columnNames).toContain('name');
+      expect(columnNames).toContain('disposition');
+      expect(columnNames).toContain('generation');
+      expect(columnNames).toContain('memory_capacity');
+      expect(columnNames).toContain('memory_used');
+      expect(columnNames).toContain('predecessor_id');
+      expect(columnNames).toContain('is_active');
+      expect(columnNames).toContain('created_at');
+      expect(columnNames.length).toBe(10);
+    });
+
+    it('should create memories table with correct columns', () => {
+      const result = db.prepare("PRAGMA table_info(memories)").all() as any[];
+      const columnNames = result.map((col) => col.name);
+
+      expect(columnNames).toContain('id');
+      expect(columnNames).toContain('agent_id');
+      expect(columnNames).toContain('content');
+      expect(columnNames).toContain('disposition_score');
+      expect(columnNames).toContain('source_type');
+      expect(columnNames).toContain('source_ref');
+      expect(columnNames).toContain('embedding_id');
+      expect(columnNames).toContain('created_at');
+      expect(columnNames.length).toBe(8);
+    });
+
+    it('should create generations table with correct columns', () => {
+      const result = db.prepare("PRAGMA table_info(generations)").all() as any[];
+      const columnNames = result.map((col) => col.name);
+
+      expect(columnNames).toContain('id');
+      expect(columnNames).toContain('agent_id');
+      expect(columnNames).toContain('generation_num');
+      expect(columnNames).toContain('seed_memories');
+      expect(columnNames).toContain('disposition_snapshot');
+      expect(columnNames).toContain('created_at');
+      expect(columnNames).toContain('retired_at');
+      expect(columnNames.length).toBe(7);
+    });
+
+    it('should create debate_sessions table with correct columns', () => {
+      const result = db.prepare("PRAGMA table_info(debate_sessions)").all() as any[];
+      const columnNames = result.map((col) => col.name);
+
+      expect(columnNames).toContain('id');
+      expect(columnNames).toContain('council_id');
+      expect(columnNames).toContain('user_prompt');
+      expect(columnNames).toContain('phase');
+      expect(columnNames).toContain('synthesis');
+      expect(columnNames).toContain('created_at');
+      expect(columnNames).toContain('completed_at');
+      expect(columnNames.length).toBe(7);
+    });
+
+    it('should create debate_turns table with correct columns', () => {
+      const result = db.prepare("PRAGMA table_info(debate_turns)").all() as any[];
+      const columnNames = result.map((col) => col.name);
+
+      expect(columnNames).toContain('id');
+      expect(columnNames).toContain('session_id');
+      expect(columnNames).toContain('agent_id');
+      expect(columnNames).toContain('phase');
+      expect(columnNames).toContain('content');
+      expect(columnNames).toContain('created_at');
+      expect(columnNames.length).toBe(6);
+    });
+
+    it('should create adoption_history table with correct columns', () => {
+      const result = db.prepare("PRAGMA table_info(adoption_history)").all() as any[];
+      const columnNames = result.map((col) => col.name);
+
+      expect(columnNames).toContain('id');
+      expect(columnNames).toContain('agent_id');
+      expect(columnNames).toContain('session_id');
+      expect(columnNames).toContain('decision');
+      expect(columnNames).toContain('user_feedback');
+      expect(columnNames).toContain('disposition_delta');
+      expect(columnNames).toContain('created_at');
+      expect(columnNames.length).toBe(7);
+    });
+  });
+
+  describe('Indexes', () => {
+    it('should create idx_agents_council index', () => {
+      const result = db
+        .prepare("SELECT name FROM sqlite_master WHERE type='index' AND name='idx_agents_council'")
+        .all();
+      expect(result.length).toBe(1);
+    });
+
+    it('should create idx_agents_active index', () => {
+      const result = db
+        .prepare("SELECT name FROM sqlite_master WHERE type='index' AND name='idx_agents_active'")
+        .all();
+      expect(result.length).toBe(1);
+    });
+
+    it('should create idx_memories_agent index', () => {
+      const result = db
+        .prepare("SELECT name FROM sqlite_master WHERE type='index' AND name='idx_memories_agent'")
+        .all();
+      expect(result.length).toBe(1);
+    });
+
+    it('should create idx_memories_score index', () => {
+      const result = db
+        .prepare("SELECT name FROM sqlite_master WHERE type='index' AND name='idx_memories_score'")
+        .all();
+      expect(result.length).toBe(1);
+    });
+
+    it('should create idx_debate_sessions_council index', () => {
+      const result = db
+        .prepare(
+          "SELECT name FROM sqlite_master WHERE type='index' AND name='idx_debate_sessions_council'"
+        )
+        .all();
+      expect(result.length).toBe(1);
+    });
+
+    it('should create idx_debate_turns_session index', () => {
+      const result = db
+        .prepare(
+          "SELECT name FROM sqlite_master WHERE type='index' AND name='idx_debate_turns_session'"
+        )
+        .all();
+      expect(result.length).toBe(1);
+    });
+
+    it('should create idx_adoption_agent index', () => {
+      const result = db
+        .prepare("SELECT name FROM sqlite_master WHERE type='index' AND name='idx_adoption_agent'")
+        .all();
+      expect(result.length).toBe(1);
+    });
+  });
+
+  describe('Foreign Keys', () => {
+    it('should enforce foreign key constraints', () => {
+      db.exec('PRAGMA foreign_keys = ON');
+
+      // Insert a council first
+      db.prepare(
+        'INSERT INTO councils (id, name, domain, created_at) VALUES (?, ?, ?, ?)'
+      ).run('test-council', 'Test Council', 'test', Date.now());
+
+      // Try to insert an agent with non-existent council_id (should fail)
+      expect(() => {
+        db.prepare(
+          'INSERT INTO agents (id, council_id, name, disposition, created_at) VALUES (?, ?, ?, ?, ?)'
+        ).run('test-agent', 'non-existent-council', 'Test Agent', '{}', Date.now());
+      }).toThrow();
+
+      // Clean up
+      db.prepare('DELETE FROM councils WHERE id = ?').run('test-council');
+    });
+
+    it('should allow valid foreign key references', () => {
+      db.exec('PRAGMA foreign_keys = ON');
+
+      // Insert a council
+      db.prepare(
+        'INSERT INTO councils (id, name, domain, created_at) VALUES (?, ?, ?, ?)'
+      ).run('test-council-2', 'Test Council 2', 'test2', Date.now());
+
+      // Insert an agent with valid council_id
+      expect(() => {
+        db.prepare(
+          'INSERT INTO agents (id, council_id, name, disposition, created_at) VALUES (?, ?, ?, ?, ?)'
+        ).run('test-agent-2', 'test-council-2', 'Test Agent 2', '{}', Date.now());
+      }).not.toThrow();
+
+      // Clean up
+      db.prepare('DELETE FROM agents WHERE id = ?').run('test-agent-2');
+      db.prepare('DELETE FROM councils WHERE id = ?').run('test-council-2');
+    });
+  });
+
+  describe('Table Existence', () => {
+    it('should have all 7 tables created', () => {
+      const result = db
+        .prepare(
+          "SELECT name FROM sqlite_master WHERE type='table' AND name NOT LIKE 'sqlite_%'"
+        )
+        .all() as any[];
+
+      const tableNames = result.map((row) => row.name).sort();
+      const expectedTables = [
+        'adoption_history',
+        'agents',
+        'councils',
+        'debate_sessions',
+        'debate_turns',
+        'generations',
+        'memories',
+      ].sort();
+
+      expect(tableNames).toEqual(expectedTables);
+    });
+  });
+});

--- a/src/council/db.ts
+++ b/src/council/db.ts
@@ -1,0 +1,107 @@
+import { Database } from 'bun:sqlite';
+import { join } from 'path';
+import { homedir } from 'os';
+import { mkdirSync } from 'fs';
+
+const DB_DIR = join(homedir(), '.clawdbot');
+const DEFAULT_DB_PATH = join(DB_DIR, 'task-queue.db');
+
+export function initCouncilDb(dbPath: string = DEFAULT_DB_PATH): Database {
+  mkdirSync(DB_DIR, { recursive: true });
+
+  const db = new Database(dbPath);
+  db.exec('PRAGMA journal_mode = WAL');
+  db.exec('PRAGMA foreign_keys = ON');
+
+  db.exec(`
+    CREATE TABLE IF NOT EXISTS councils (
+      id TEXT PRIMARY KEY,
+      name TEXT NOT NULL,
+      domain TEXT NOT NULL UNIQUE,
+      description TEXT,
+      created_at INTEGER NOT NULL
+    );
+
+    CREATE TABLE IF NOT EXISTS agents (
+      id TEXT PRIMARY KEY,
+      council_id TEXT NOT NULL,
+      name TEXT NOT NULL,
+      disposition TEXT NOT NULL,
+      generation INTEGER DEFAULT 1,
+      memory_capacity INTEGER DEFAULT 100,
+      memory_used INTEGER DEFAULT 0,
+      predecessor_id TEXT,
+      is_active INTEGER DEFAULT 1,
+      created_at INTEGER NOT NULL,
+      FOREIGN KEY (council_id) REFERENCES councils(id),
+      FOREIGN KEY (predecessor_id) REFERENCES agents(id)
+    );
+
+    CREATE TABLE IF NOT EXISTS memories (
+      id TEXT PRIMARY KEY,
+      agent_id TEXT NOT NULL,
+      content TEXT NOT NULL,
+      disposition_score REAL NOT NULL,
+      source_type TEXT NOT NULL,
+      source_ref TEXT,
+      embedding_id TEXT,
+      created_at INTEGER NOT NULL,
+      FOREIGN KEY (agent_id) REFERENCES agents(id)
+    );
+
+    CREATE TABLE IF NOT EXISTS generations (
+      id TEXT PRIMARY KEY,
+      agent_id TEXT NOT NULL,
+      generation_num INTEGER NOT NULL,
+      seed_memories TEXT,
+      disposition_snapshot TEXT,
+      created_at INTEGER NOT NULL,
+      retired_at INTEGER,
+      FOREIGN KEY (agent_id) REFERENCES agents(id)
+    );
+
+    CREATE TABLE IF NOT EXISTS debate_sessions (
+      id TEXT PRIMARY KEY,
+      council_id TEXT NOT NULL,
+      user_prompt TEXT NOT NULL,
+      phase TEXT DEFAULT 'position',
+      synthesis TEXT,
+      created_at INTEGER NOT NULL,
+      completed_at INTEGER,
+      FOREIGN KEY (council_id) REFERENCES councils(id)
+    );
+
+    CREATE TABLE IF NOT EXISTS debate_turns (
+      id TEXT PRIMARY KEY,
+      session_id TEXT NOT NULL,
+      agent_id TEXT NOT NULL,
+      phase TEXT NOT NULL,
+      content TEXT NOT NULL,
+      created_at INTEGER NOT NULL,
+      FOREIGN KEY (session_id) REFERENCES debate_sessions(id),
+      FOREIGN KEY (agent_id) REFERENCES agents(id)
+    );
+
+    CREATE TABLE IF NOT EXISTS adoption_history (
+      id TEXT PRIMARY KEY,
+      agent_id TEXT NOT NULL,
+      session_id TEXT NOT NULL,
+      decision TEXT NOT NULL,
+      user_feedback TEXT,
+      disposition_delta TEXT,
+      created_at INTEGER NOT NULL,
+      FOREIGN KEY (agent_id) REFERENCES agents(id),
+      FOREIGN KEY (session_id) REFERENCES debate_sessions(id)
+    );
+
+    CREATE INDEX IF NOT EXISTS idx_agents_council ON agents(council_id);
+    CREATE INDEX IF NOT EXISTS idx_agents_active ON agents(is_active);
+    CREATE INDEX IF NOT EXISTS idx_memories_agent ON memories(agent_id);
+    CREATE INDEX IF NOT EXISTS idx_memories_score ON memories(disposition_score);
+    CREATE INDEX IF NOT EXISTS idx_debate_sessions_council ON debate_sessions(council_id);
+    CREATE INDEX IF NOT EXISTS idx_debate_turns_session ON debate_turns(session_id);
+    CREATE INDEX IF NOT EXISTS idx_adoption_agent ON adoption_history(agent_id);
+  `);
+
+  return db;
+}

--- a/src/council/debate/debate-engine.test.ts
+++ b/src/council/debate/debate-engine.test.ts
@@ -1,0 +1,481 @@
+import { describe, it, expect, beforeEach, afterEach } from 'bun:test';
+import type {
+  Agent,
+  DebateSession,
+  AgentPosition,
+  AgentChallenge,
+  AgentDisposition,
+} from '../types';
+import { DebateEngine } from './debate-engine';
+import { debateSessionDb, debateTurnDb, agentDb } from '../storage/council-db';
+import { setDb } from '../storage/council-db';
+import { Database } from 'bun:sqlite';
+
+// Mock memory manager
+const mockMemoryManager = {
+  getRelevantMemories: async () => [
+    { id: 'mem1', content: 'Previous insight about cost', agentId: 'agent1', dispositionScore: 0.8, sourceType: 'debate' as const, createdAt: Date.now() },
+    { id: 'mem2', content: 'Quality matters most', agentId: 'agent1', dispositionScore: 0.9, sourceType: 'debate' as const, createdAt: Date.now() },
+  ],
+};
+
+// Create test database
+function createTestDb(): Database {
+  const db = new Database(':memory:');
+
+  // Create tables
+  db.exec(`
+    CREATE TABLE councils (
+      id TEXT PRIMARY KEY,
+      name TEXT NOT NULL,
+      domain TEXT NOT NULL,
+      description TEXT,
+      created_at INTEGER NOT NULL
+    );
+
+    CREATE TABLE agents (
+      id TEXT PRIMARY KEY,
+      council_id TEXT NOT NULL,
+      name TEXT NOT NULL,
+      disposition TEXT NOT NULL,
+      generation INTEGER NOT NULL,
+      memory_capacity INTEGER NOT NULL,
+      memory_used INTEGER NOT NULL,
+      predecessor_id TEXT,
+      is_active INTEGER NOT NULL,
+      created_at INTEGER NOT NULL,
+      FOREIGN KEY (council_id) REFERENCES councils(id)
+    );
+
+    CREATE TABLE debate_sessions (
+      id TEXT PRIMARY KEY,
+      council_id TEXT NOT NULL,
+      user_prompt TEXT NOT NULL,
+      phase TEXT NOT NULL,
+      synthesis TEXT,
+      created_at INTEGER NOT NULL,
+      completed_at INTEGER,
+      FOREIGN KEY (council_id) REFERENCES councils(id)
+    );
+
+    CREATE TABLE debate_turns (
+      id TEXT PRIMARY KEY,
+      session_id TEXT NOT NULL,
+      agent_id TEXT NOT NULL,
+      phase TEXT NOT NULL,
+      content TEXT NOT NULL,
+      created_at INTEGER NOT NULL,
+      FOREIGN KEY (session_id) REFERENCES debate_sessions(id),
+      FOREIGN KEY (agent_id) REFERENCES agents(id)
+    );
+
+    CREATE TABLE memories (
+      id TEXT PRIMARY KEY,
+      agent_id TEXT NOT NULL,
+      content TEXT NOT NULL,
+      disposition_score REAL NOT NULL,
+      source_type TEXT NOT NULL,
+      source_ref TEXT,
+      embedding_id TEXT,
+      created_at INTEGER NOT NULL,
+      FOREIGN KEY (agent_id) REFERENCES agents(id)
+    );
+  `);
+
+  return db;
+}
+
+describe('DebateEngine', () => {
+  let engine: DebateEngine;
+  let testDb: Database;
+  let mockCouncilId: string;
+  let mockAgents: Agent[];
+  let mockSession: DebateSession;
+
+  beforeEach(() => {
+    testDb = createTestDb();
+    setDb(testDb);
+
+    engine = new DebateEngine(mockMemoryManager as any);
+
+    // Create test council
+    mockCouncilId = 'council_test_' + Date.now();
+    testDb.prepare(`
+      INSERT INTO councils (id, name, domain, description, created_at)
+      VALUES (?, ?, ?, ?, ?)
+    `).run(mockCouncilId, 'Test Council', 'lifestyle', 'Test', Date.now());
+
+    // Create test agents
+    const disposition: AgentDisposition = {
+      orientation: 'pragmatic',
+      filterCriteria: {
+        keywords: ['cost', 'quality'],
+        sentimentBias: 'neutral',
+        noveltyPreference: 'balanced',
+        riskTolerance: 'moderate',
+      },
+      priorities: {
+        cost: 0.4,
+        quality: 0.3,
+        novelty: 0.2,
+        reliability: 0.1,
+      },
+      voice: {
+        tone: 'analytical',
+        vocabulary: ['consider', 'analyze', 'evaluate'],
+      },
+    };
+
+    mockAgents = [
+      {
+        id: 'agent1',
+        councilId: mockCouncilId,
+        name: 'Cost Analyst',
+        disposition: { ...disposition, priorities: { cost: 0.5, quality: 0.2, novelty: 0.1, reliability: 0.2 } },
+        generation: 1,
+        memoryCapacity: 100,
+        memoryUsed: 0,
+        isActive: true,
+        createdAt: Date.now(),
+      },
+      {
+        id: 'agent2',
+        councilId: mockCouncilId,
+        name: 'Quality Champion',
+        disposition: { ...disposition, priorities: { cost: 0.1, quality: 0.6, novelty: 0.2, reliability: 0.1 } },
+        generation: 1,
+        memoryCapacity: 100,
+        memoryUsed: 0,
+        isActive: true,
+        createdAt: Date.now(),
+      },
+      {
+        id: 'agent3',
+        councilId: mockCouncilId,
+        name: 'Innovation Scout',
+        disposition: { ...disposition, priorities: { cost: 0.1, quality: 0.2, novelty: 0.6, reliability: 0.1 } },
+        generation: 1,
+        memoryCapacity: 100,
+        memoryUsed: 0,
+        isActive: true,
+        createdAt: Date.now(),
+      },
+    ];
+
+    // Insert agents into DB
+    for (const agent of mockAgents) {
+      testDb.prepare(`
+        INSERT INTO agents (id, council_id, name, disposition, generation, memory_capacity, memory_used, is_active, created_at)
+        VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)
+      `).run(
+        agent.id,
+        agent.councilId,
+        agent.name,
+        JSON.stringify(agent.disposition),
+        agent.generation,
+        agent.memoryCapacity,
+        agent.memoryUsed,
+        agent.isActive ? 1 : 0,
+        agent.createdAt
+      );
+    }
+
+    // Create test session
+    mockSession = {
+      id: 'session_test_' + Date.now(),
+      councilId: mockCouncilId,
+      userPrompt: 'Should we invest in new technology?',
+      phase: 'position',
+      createdAt: Date.now(),
+    };
+
+    testDb.prepare(`
+      INSERT INTO debate_sessions (id, council_id, user_prompt, phase, created_at)
+      VALUES (?, ?, ?, ?, ?)
+    `).run(mockSession.id, mockSession.councilId, mockSession.userPrompt, mockSession.phase, mockSession.createdAt);
+  });
+
+  afterEach(() => {
+    testDb.close();
+  });
+
+  describe('runDebate', () => {
+    it('should return a complete DebateResult', async () => {
+      const result = await engine.runDebate(mockSession, mockAgents);
+
+      expect(result).toBeDefined();
+      expect(result.sessionId).toBe(mockSession.id);
+      expect(result.council).toBe('lifestyle');
+      expect(result.phases).toBeDefined();
+      expect(result.phases.positions).toBeDefined();
+      expect(result.phases.challenges).toBeDefined();
+      expect(result.phases.synthesis).toBeDefined();
+      expect(result.recommendation).toBeDefined();
+      expect(result.confidence).toBeGreaterThanOrEqual(0);
+      expect(result.confidence).toBeLessThanOrEqual(1);
+      expect(result.memoriesCreated).toBe(0);
+    });
+
+    it('should update session phase through debate lifecycle', async () => {
+      await engine.runDebate(mockSession, mockAgents);
+
+      const finalSession = debateSessionDb.getById(mockSession.id);
+      expect(finalSession).toBeDefined();
+      expect(finalSession?.phase).toBe('complete');
+      expect(finalSession?.completedAt).toBeDefined();
+      expect(finalSession?.synthesis).toBeDefined();
+    });
+  });
+
+  describe('runPositionPhase', () => {
+    it('should generate positions for all agents', async () => {
+      const positions = await engine.runPositionPhase(mockSession, mockAgents);
+
+      expect(positions).toHaveLength(mockAgents.length);
+      expect(positions.every(p => p.agentId)).toBe(true);
+      expect(positions.every(p => p.agentName)).toBe(true);
+      expect(positions.every(p => p.position)).toBe(true);
+      expect(positions.every(p => p.keyPoints)).toBe(true);
+    });
+
+    it('should store positions in database', async () => {
+      await engine.runPositionPhase(mockSession, mockAgents);
+
+      const turns = testDb.prepare('SELECT * FROM debate_turns WHERE session_id = ? AND phase = ?').all(mockSession.id, 'position') as any[];
+      expect(turns).toHaveLength(mockAgents.length);
+    });
+  });
+
+  describe('generatePosition', () => {
+    it('should use agent disposition to generate position', () => {
+      const position = engine.generatePosition(mockAgents[0], 'Test prompt', ['memory1', 'memory2']);
+
+      expect(position.agentId).toBe(mockAgents[0].id);
+      expect(position.agentName).toBe(mockAgents[0].name);
+      expect(position.position).toBeDefined();
+      expect(position.keyPoints).toBeDefined();
+      expect(Array.isArray(position.keyPoints)).toBe(true);
+    });
+
+    it('should include cost consideration for cost-focused agent', () => {
+      const position = engine.generatePosition(mockAgents[0], 'Test prompt', []);
+
+      expect(position.keyPoints.some(p => p.toLowerCase().includes('cost'))).toBe(true);
+    });
+
+    it('should include quality consideration for quality-focused agent', () => {
+      const position = engine.generatePosition(mockAgents[1], 'Test prompt', []);
+
+      expect(position.keyPoints.some(p => p.toLowerCase().includes('quality'))).toBe(true);
+    });
+
+    it('should include novelty consideration for novelty-focused agent', () => {
+      const position = engine.generatePosition(mockAgents[2], 'Test prompt', []);
+
+      expect(position.keyPoints.some(p => p.toLowerCase().includes('new'))).toBe(true);
+    });
+  });
+
+  describe('runChallengePhase', () => {
+    it('should generate challenges between agents', async () => {
+      const positions = await engine.runPositionPhase(mockSession, mockAgents);
+      const challenges = await engine.runChallengePhase(mockSession, positions, mockAgents);
+
+      expect(challenges).toHaveLength(mockAgents.length);
+      expect(challenges.every(c => c.challengerId)).toBe(true);
+      expect(challenges.every(c => c.targetId)).toBe(true);
+      expect(challenges.every(c => c.challenge)).toBe(true);
+    });
+
+    it('should store challenges in database', async () => {
+      const positions = await engine.runPositionPhase(mockSession, mockAgents);
+      await engine.runChallengePhase(mockSession, positions, mockAgents);
+
+      const turns = testDb.prepare('SELECT * FROM debate_turns WHERE session_id = ? AND phase = ?').all(mockSession.id, 'challenge') as any[];
+      expect(turns).toHaveLength(mockAgents.length);
+    });
+  });
+
+  describe('generateChallenge', () => {
+    it('should create valid challenge', async () => {
+      const positions = await engine.runPositionPhase(mockSession, mockAgents);
+      const challenge = engine.generateChallenge(mockAgents[0], mockAgents[1], positions[1]);
+
+      expect(challenge.challengerId).toBe(mockAgents[0].id);
+      expect(challenge.challengerName).toBe(mockAgents[0].name);
+      expect(challenge.targetId).toBe(mockAgents[1].id);
+      expect(challenge.targetName).toBe(mockAgents[1].name);
+      expect(challenge.challenge).toBeDefined();
+      expect(challenge.counterPoints).toBeDefined();
+    });
+
+    it('should generate counter-points based on priority differences', async () => {
+      const positions = await engine.runPositionPhase(mockSession, mockAgents);
+      const challenge = engine.generateChallenge(mockAgents[0], mockAgents[1], positions[1]);
+
+      // Cost analyst (0.5) vs Quality champion (0.1) - should have counter-point
+      expect(challenge.counterPoints.length).toBeGreaterThan(0);
+    });
+  });
+
+  describe('runSynthesisPhase', () => {
+    it('should produce synthesis text', async () => {
+      const positions = await engine.runPositionPhase(mockSession, mockAgents);
+      const challenges = await engine.runChallengePhase(mockSession, positions, mockAgents);
+      const synthesis = await engine.runSynthesisPhase(mockSession, positions, challenges);
+
+      expect(synthesis).toBeDefined();
+      expect(typeof synthesis).toBe('string');
+      expect(synthesis.length).toBeGreaterThan(0);
+      expect(synthesis).toContain('RECOMMENDATION');
+    });
+  });
+
+  describe('findConsensus', () => {
+    it('should identify common key points', async () => {
+      const positions = await engine.runPositionPhase(mockSession, mockAgents);
+      const consensus = engine.findConsensus(positions);
+
+      expect(Array.isArray(consensus)).toBe(true);
+    });
+
+    it('should return empty array when no consensus', () => {
+      const positions: AgentPosition[] = [
+        {
+          agentId: 'a1',
+          agentName: 'Agent 1',
+          position: 'Position 1',
+          keyPoints: ['Point A', 'Point B'],
+          relevantMemories: [],
+        },
+        {
+          agentId: 'a2',
+          agentName: 'Agent 2',
+          position: 'Position 2',
+          keyPoints: ['Point C', 'Point D'],
+          relevantMemories: [],
+        },
+      ];
+
+      const consensus = engine.findConsensus(positions);
+      expect(consensus).toHaveLength(0);
+    });
+
+    it('should find consensus when points repeat', () => {
+      const positions: AgentPosition[] = [
+        {
+          agentId: 'a1',
+          agentName: 'Agent 1',
+          position: 'Position 1',
+          keyPoints: ['Common Point', 'Unique A'],
+          relevantMemories: [],
+        },
+        {
+          agentId: 'a2',
+          agentName: 'Agent 2',
+          position: 'Position 2',
+          keyPoints: ['Common Point', 'Unique B'],
+          relevantMemories: [],
+        },
+      ];
+
+      const consensus = engine.findConsensus(positions);
+      expect(consensus).toContain('Common Point');
+    });
+  });
+
+  describe('findTensions', () => {
+    it('should identify tension points from challenges', async () => {
+      const positions = await engine.runPositionPhase(mockSession, mockAgents);
+      const challenges = await engine.runChallengePhase(mockSession, positions, mockAgents);
+      const tensions = engine.findTensions(challenges);
+
+      expect(Array.isArray(tensions)).toBe(true);
+    });
+
+    it('should return empty array when no tensions', () => {
+      const challenges: AgentChallenge[] = [
+        {
+          challengerId: 'c1',
+          challengerName: 'Challenger 1',
+          targetId: 't1',
+          targetName: 'Target 1',
+          challenge: 'Challenge text',
+          counterPoints: [],
+        },
+      ];
+
+      const tensions = engine.findTensions(challenges);
+      expect(tensions).toHaveLength(0);
+    });
+
+    it('should include challenger and target names in tension', async () => {
+      const positions = await engine.runPositionPhase(mockSession, mockAgents);
+      const challenges = await engine.runChallengePhase(mockSession, positions, mockAgents);
+      const tensions = engine.findTensions(challenges);
+
+      if (tensions.length > 0) {
+        expect(tensions[0]).toContain('vs');
+      }
+    });
+  });
+
+  describe('calculateConfidence', () => {
+    it('should return value between 0 and 1', async () => {
+      const positions = await engine.runPositionPhase(mockSession, mockAgents);
+      const confidence = engine.calculateConfidence(positions);
+
+      expect(confidence).toBeGreaterThanOrEqual(0);
+      expect(confidence).toBeLessThanOrEqual(1);
+    });
+
+    it('should return 0 for empty positions', () => {
+      const confidence = engine.calculateConfidence([]);
+      expect(confidence).toBe(0);
+    });
+
+    it('should return higher confidence for aligned positions', () => {
+      const alignedPositions: AgentPosition[] = [
+        {
+          agentId: 'a1',
+          agentName: 'Agent 1',
+          position: 'Position 1',
+          keyPoints: ['Point A', 'Point B', 'Point C'],
+          relevantMemories: [],
+        },
+        {
+          agentId: 'a2',
+          agentName: 'Agent 2',
+          position: 'Position 2',
+          keyPoints: ['Point A', 'Point B', 'Point C'],
+          relevantMemories: [],
+        },
+      ];
+
+      const confidence = engine.calculateConfidence(alignedPositions);
+      expect(confidence).toBeGreaterThan(0.5);
+    });
+
+    it('should return lower confidence for divergent positions', () => {
+      const divergentPositions: AgentPosition[] = [
+        {
+          agentId: 'a1',
+          agentName: 'Agent 1',
+          position: 'Position 1',
+          keyPoints: ['Point A', 'Point B'],
+          relevantMemories: [],
+        },
+        {
+          agentId: 'a2',
+          agentName: 'Agent 2',
+          position: 'Position 2',
+          keyPoints: ['Point C', 'Point D'],
+          relevantMemories: [],
+        },
+      ];
+
+      const confidence = engine.calculateConfidence(divergentPositions);
+      expect(confidence).toBeLessThan(0.5);
+    });
+  });
+});

--- a/src/council/debate/debate-engine.ts
+++ b/src/council/debate/debate-engine.ts
@@ -1,0 +1,217 @@
+import type {
+  Agent,
+  DebateSession,
+  DebateResult,
+  AgentPosition,
+  AgentChallenge,
+  DebatePhase,
+  Memory,
+} from '../types';
+import { debateSessionDb, debateTurnDb } from '../storage/council-db';
+
+export interface PositionPrompt {
+  agent: Agent;
+  userPrompt: string;
+  relevantMemories: string[];
+}
+
+export interface ChallengePrompt {
+  challenger: Agent;
+  target: Agent;
+  targetPosition: string;
+}
+
+export interface MemoryManager {
+  getRelevantMemories(agentId: string, prompt: string, limit: number): Promise<Memory[]>;
+}
+
+export class DebateEngine {
+  constructor(private memoryManager: MemoryManager) {}
+
+  async runDebate(session: DebateSession, agents: Agent[]): Promise<DebateResult> {
+    debateSessionDb.update(session.id, { phase: 'position' });
+
+    const positions = await this.runPositionPhase(session, agents);
+
+    debateSessionDb.update(session.id, { phase: 'challenge' });
+
+    const challenges = await this.runChallengePhase(session, positions, agents);
+
+    debateSessionDb.update(session.id, { phase: 'synthesis' });
+
+    const synthesis = await this.runSynthesisPhase(session, positions, challenges);
+
+    debateSessionDb.update(session.id, {
+      phase: 'complete',
+      synthesis,
+      completedAt: Date.now(),
+    });
+
+    const confidence = this.calculateConfidence(positions);
+
+    return {
+      sessionId: session.id,
+      council: 'lifestyle',
+      phases: { positions, challenges, synthesis },
+      recommendation: synthesis,
+      confidence,
+      memoriesCreated: 0,
+    };
+  }
+
+  async runPositionPhase(session: DebateSession, agents: Agent[]): Promise<AgentPosition[]> {
+    const positions: AgentPosition[] = [];
+
+    for (const agent of agents) {
+      const memories = await this.memoryManager.getRelevantMemories(agent.id, session.userPrompt, 3);
+
+      const position = this.generatePosition(agent, session.userPrompt, memories.map((m) => m.content));
+
+      debateTurnDb.insert({
+        sessionId: session.id,
+        agentId: agent.id,
+        phase: 'position',
+        content: position.position,
+      });
+
+      positions.push(position);
+    }
+
+    return positions;
+  }
+
+  generatePosition(agent: Agent, userPrompt: string, memories: string[]): AgentPosition {
+    const { disposition } = agent;
+    const { priorities, voice } = disposition;
+
+    const keyPoints: string[] = [];
+
+    if (priorities.cost > 0.3) {
+      keyPoints.push('Consider the cost-value tradeoff');
+    }
+    if (priorities.quality > 0.3) {
+      keyPoints.push('Quality should be the priority');
+    }
+    if (priorities.novelty > 0.3) {
+      keyPoints.push('This is an opportunity to try something new');
+    }
+    if (priorities.reliability > 0.3) {
+      keyPoints.push('Stick with what has worked before');
+    }
+
+    const position = `From my ${voice.tone} perspective on "${userPrompt}": ${keyPoints.join('. ')}.`;
+
+    return {
+      agentId: agent.id,
+      agentName: agent.name,
+      position,
+      keyPoints,
+      relevantMemories: memories,
+    };
+  }
+
+  async runChallengePhase(
+    session: DebateSession,
+    positions: AgentPosition[],
+    agents: Agent[]
+  ): Promise<AgentChallenge[]> {
+    const challenges: AgentChallenge[] = [];
+
+    for (let i = 0; i < agents.length; i++) {
+      const challenger = agents[i];
+      const targetIdx = (i + 1) % agents.length;
+      const target = agents[targetIdx];
+      const targetPosition = positions[targetIdx];
+
+      const challenge = this.generateChallenge(challenger, target, targetPosition);
+
+      debateTurnDb.insert({
+        sessionId: session.id,
+        agentId: challenger.id,
+        phase: 'challenge',
+        content: challenge.challenge,
+      });
+
+      challenges.push(challenge);
+    }
+
+    return challenges;
+  }
+
+  generateChallenge(challenger: Agent, target: Agent, targetPosition: AgentPosition): AgentChallenge {
+    const counterPoints: string[] = [];
+
+    if (challenger.disposition.priorities.cost > target.disposition.priorities.cost) {
+      counterPoints.push('You overlooked the cost implications');
+    }
+    if (challenger.disposition.priorities.quality > target.disposition.priorities.quality) {
+      counterPoints.push('Quality concerns were not adequately addressed');
+    }
+    if (challenger.disposition.priorities.novelty > target.disposition.priorities.novelty) {
+      counterPoints.push('You missed the opportunity for innovation');
+    }
+    if (challenger.disposition.priorities.reliability > target.disposition.priorities.reliability) {
+      counterPoints.push('The reliability factor was underweighted');
+    }
+
+    const challenge =
+      `As ${challenger.name}, I challenge ${target.name}: ${counterPoints.join('. ') || 'Your perspective needs more nuance'}.`;
+
+    return {
+      challengerId: challenger.id,
+      challengerName: challenger.name,
+      targetId: target.id,
+      targetName: target.name,
+      challenge,
+      counterPoints,
+    };
+  }
+
+  async runSynthesisPhase(
+    session: DebateSession,
+    positions: AgentPosition[],
+    challenges: AgentChallenge[]
+  ): Promise<string> {
+    const consensusPoints = this.findConsensus(positions);
+    const tensionPoints = this.findTensions(challenges);
+
+    return `Based on the council's deliberation on "${session.userPrompt}":
+
+RECOMMENDATION: ${consensusPoints.length > 0 ? consensusPoints.join(' ') : 'Consider all perspectives carefully.'}
+
+CONSENSUS POINTS: ${consensusPoints.join('; ') || 'Limited consensus reached.'}
+
+KEY TENSIONS: ${tensionPoints.join('; ') || 'No major disagreements.'}`;
+  }
+
+  findConsensus(positions: AgentPosition[]): string[] {
+    const allPoints = positions.flatMap((p) => p.keyPoints);
+    const pointCounts = new Map<string, number>();
+
+    for (const point of allPoints) {
+      pointCounts.set(point, (pointCounts.get(point) || 0) + 1);
+    }
+
+    return Array.from(pointCounts.entries())
+      .filter(([_, count]) => count >= 2)
+      .map(([point]) => point);
+  }
+
+  findTensions(challenges: AgentChallenge[]): string[] {
+    return challenges
+      .filter((c) => c.counterPoints.length > 0)
+      .map((c) => `${c.challengerName} vs ${c.targetName}: ${c.counterPoints[0]}`);
+  }
+
+  calculateConfidence(positions: AgentPosition[]): number {
+    if (positions.length === 0) return 0;
+
+    const allPoints = positions.flatMap((p) => p.keyPoints);
+    const uniquePoints = new Set(allPoints);
+
+    const overlapRatio = uniquePoints.size / allPoints.length;
+    return Math.max(0, Math.min(1, 1 - overlapRatio + 0.3));
+  }
+}
+
+export const debateEngine = new DebateEngine(null as any);

--- a/src/council/debate/debate-engine.ts
+++ b/src/council/debate/debate-engine.ts
@@ -8,6 +8,8 @@ import type {
   Memory,
 } from '../types';
 import { debateSessionDb, debateTurnDb } from '../storage/council-db';
+import { MemoryManager as MemoryManagerClass } from '../memory/memory-manager';
+import { vectorStore } from '../storage/vector-store';
 
 export interface PositionPrompt {
   agent: Agent;
@@ -214,4 +216,4 @@ KEY TENSIONS: ${tensionPoints.join('; ') || 'No major disagreements.'}`;
   }
 }
 
-export const debateEngine = new DebateEngine(null as any);
+export const debateEngine = new DebateEngine(new MemoryManagerClass(vectorStore));

--- a/src/council/generation/generation-manager.test.ts
+++ b/src/council/generation/generation-manager.test.ts
@@ -1,0 +1,365 @@
+import { describe, it, expect, beforeEach, afterEach } from 'bun:test';
+import { Database } from 'bun:sqlite';
+import { initCouncilDb } from '../db';
+import { setDb, agentDb, memoryDb, generationDb } from '../storage/council-db';
+import { GenerationManager } from './generation-manager';
+import type { Agent, AgentDisposition } from '../types';
+
+describe('GenerationManager', () => {
+  let db: Database;
+  let manager: GenerationManager;
+  let testDisposition: AgentDisposition;
+  let testAgent: Agent;
+
+  beforeEach(() => {
+    db = new Database(':memory:');
+    db.exec('PRAGMA journal_mode = WAL');
+    db.exec('PRAGMA foreign_keys = ON');
+
+    db.exec(`
+      CREATE TABLE IF NOT EXISTS councils (
+        id TEXT PRIMARY KEY,
+        name TEXT NOT NULL,
+        domain TEXT NOT NULL UNIQUE,
+        description TEXT,
+        created_at INTEGER NOT NULL
+      );
+
+      CREATE TABLE IF NOT EXISTS agents (
+        id TEXT PRIMARY KEY,
+        council_id TEXT NOT NULL,
+        name TEXT NOT NULL,
+        disposition TEXT NOT NULL,
+        generation INTEGER DEFAULT 1,
+        memory_capacity INTEGER DEFAULT 100,
+        memory_used INTEGER DEFAULT 0,
+        predecessor_id TEXT,
+        is_active INTEGER DEFAULT 1,
+        created_at INTEGER NOT NULL,
+        FOREIGN KEY (council_id) REFERENCES councils(id),
+        FOREIGN KEY (predecessor_id) REFERENCES agents(id)
+      );
+
+      CREATE TABLE IF NOT EXISTS memories (
+        id TEXT PRIMARY KEY,
+        agent_id TEXT NOT NULL,
+        content TEXT NOT NULL,
+        disposition_score REAL NOT NULL,
+        source_type TEXT NOT NULL,
+        source_ref TEXT,
+        embedding_id TEXT,
+        created_at INTEGER NOT NULL,
+        FOREIGN KEY (agent_id) REFERENCES agents(id)
+      );
+
+      CREATE TABLE IF NOT EXISTS generations (
+        id TEXT PRIMARY KEY,
+        agent_id TEXT NOT NULL,
+        generation_num INTEGER NOT NULL,
+        seed_memories TEXT,
+        disposition_snapshot TEXT NOT NULL,
+        created_at INTEGER NOT NULL,
+        retired_at INTEGER,
+        FOREIGN KEY (agent_id) REFERENCES agents(id)
+      );
+    `);
+    setDb(db);
+    manager = new GenerationManager();
+
+    testDisposition = {
+      orientation: 'pragmatic',
+      filterCriteria: {
+        keywords: ['efficiency', 'cost'],
+        sentimentBias: 'neutral',
+        noveltyPreference: 'low',
+        riskTolerance: 'low',
+      },
+      priorities: {
+        cost: 0.4,
+        quality: 0.3,
+        novelty: 0.1,
+        reliability: 0.2,
+      },
+      voice: {
+        tone: 'direct',
+        vocabulary: ['practical', 'proven'],
+      },
+    };
+
+    const stmt = db.prepare(
+      'INSERT INTO councils (id, name, domain, description, created_at) VALUES (?, ?, ?, ?, ?)'
+    );
+    stmt.run('council_test', 'Test Council', 'lifestyle', 'Test', Date.now());
+
+    testAgent = agentDb.insert({
+      councilId: 'council_test',
+      name: 'TestAgent',
+      disposition: testDisposition,
+      generation: 1,
+      memoryCapacity: 100,
+      memoryUsed: 0,
+      isActive: true,
+    });
+  });
+
+  afterEach(() => {
+    db.close();
+  });
+
+  describe('shouldSpawnSuccessor', () => {
+    it('returns true when agent is at memory capacity', () => {
+      const agent = agentDb.insert({
+        councilId: 'council_test',
+        name: 'FullAgent',
+        disposition: testDisposition,
+        generation: 1,
+        memoryCapacity: 100,
+        memoryUsed: 100,
+        isActive: true,
+      });
+
+      expect(manager.shouldSpawnSuccessor(agent)).toBe(true);
+    });
+
+    it('returns false when agent is below memory capacity', () => {
+      const agent = agentDb.insert({
+        councilId: 'council_test',
+        name: 'PartialAgent',
+        disposition: testDisposition,
+        generation: 1,
+        memoryCapacity: 100,
+        memoryUsed: 50,
+        isActive: true,
+      });
+
+      expect(manager.shouldSpawnSuccessor(agent)).toBe(false);
+    });
+
+    it('returns false when agent has no memories', () => {
+      expect(manager.shouldSpawnSuccessor(testAgent)).toBe(false);
+    });
+  });
+
+  describe('spawnSuccessor', () => {
+    it('marks predecessor as inactive', async () => {
+      // Add some memories to trigger succession
+      for (let i = 0; i < 100; i++) {
+        memoryDb.insert({
+          agentId: testAgent.id,
+          content: `Memory ${i}`,
+          dispositionScore: Math.random(),
+          sourceType: 'debate',
+        });
+      }
+
+      const updatedAgent = agentDb.getById(testAgent.id)!;
+      updatedAgent.memoryUsed = 100;
+      agentDb.update(testAgent.id, { memoryUsed: 100 });
+
+      const event = await manager.spawnSuccessor(updatedAgent);
+
+      const predecessor = agentDb.getById(event.predecessorId)!;
+      expect(predecessor.isActive).toBe(false);
+    });
+
+    it('creates successor with incremented generation', async () => {
+      // Add memories
+      for (let i = 0; i < 100; i++) {
+        memoryDb.insert({
+          agentId: testAgent.id,
+          content: `Memory ${i}`,
+          dispositionScore: Math.random(),
+          sourceType: 'debate',
+        });
+      }
+
+      agentDb.update(testAgent.id, { memoryUsed: 100 });
+      const updatedAgent = agentDb.getById(testAgent.id)!;
+
+      const event = await manager.spawnSuccessor(updatedAgent);
+      const successor = agentDb.getById(event.successorId)!;
+
+      expect(successor.generation).toBe(testAgent.generation + 1);
+      expect(successor.generation).toBe(2);
+    });
+
+    it('copies seed memories (top 20%)', async () => {
+      // Add 100 memories with varying scores
+      for (let i = 0; i < 100; i++) {
+        memoryDb.insert({
+          agentId: testAgent.id,
+          content: `Memory ${i}`,
+          dispositionScore: i / 100, // 0.0 to 0.99
+          sourceType: 'debate',
+        });
+      }
+
+      agentDb.update(testAgent.id, { memoryUsed: 100 });
+      const updatedAgent = agentDb.getById(testAgent.id)!;
+
+      const event = await manager.spawnSuccessor(updatedAgent);
+      const successor = agentDb.getById(event.successorId)!;
+
+      // Should have 20% of capacity = 20 memories
+      expect(event.seedMemories.length).toBe(20);
+      expect(successor.memoryUsed).toBe(20);
+
+      // Verify seed memories were copied
+      const successorMemories = memoryDb.getByAgent(successor.id);
+      expect(successorMemories.length).toBe(20);
+
+      // Verify they're marked as 'seed' source
+      successorMemories.forEach((mem) => {
+        expect(mem.sourceType).toBe('seed');
+      });
+    });
+
+    it('preserves disposition in successor', async () => {
+      // Add memories
+      for (let i = 0; i < 100; i++) {
+        memoryDb.insert({
+          agentId: testAgent.id,
+          content: `Memory ${i}`,
+          dispositionScore: Math.random(),
+          sourceType: 'debate',
+        });
+      }
+
+      agentDb.update(testAgent.id, { memoryUsed: 100 });
+      const updatedAgent = agentDb.getById(testAgent.id)!;
+
+      const event = await manager.spawnSuccessor(updatedAgent);
+      const successor = agentDb.getById(event.successorId)!;
+
+      expect(successor.disposition).toEqual(testDisposition);
+      expect(event.inheritedDisposition).toEqual(testDisposition);
+    });
+
+    it('records generation event', async () => {
+      // Add memories
+      for (let i = 0; i < 100; i++) {
+        memoryDb.insert({
+          agentId: testAgent.id,
+          content: `Memory ${i}`,
+          dispositionScore: Math.random(),
+          sourceType: 'debate',
+        });
+      }
+
+      agentDb.update(testAgent.id, { memoryUsed: 100 });
+      const updatedAgent = agentDb.getById(testAgent.id)!;
+
+      const event = await manager.spawnSuccessor(updatedAgent);
+
+      const generations = generationDb.getByAgent(event.predecessorId);
+      expect(generations.length).toBeGreaterThan(0);
+
+      const latestGen = generations[0];
+      expect(latestGen.generationNum).toBe(testAgent.generation);
+      expect(latestGen.seedMemories).toEqual(event.seedMemories);
+      expect(latestGen.dispositionSnapshot).toEqual(testDisposition);
+    });
+
+    it('sets predecessor reference on successor', async () => {
+      // Add memories
+      for (let i = 0; i < 100; i++) {
+        memoryDb.insert({
+          agentId: testAgent.id,
+          content: `Memory ${i}`,
+          dispositionScore: Math.random(),
+          sourceType: 'debate',
+        });
+      }
+
+      agentDb.update(testAgent.id, { memoryUsed: 100 });
+      const updatedAgent = agentDb.getById(testAgent.id)!;
+
+      const event = await manager.spawnSuccessor(updatedAgent);
+      const successor = agentDb.getById(event.successorId)!;
+
+      expect(successor.predecessorId).toBe(testAgent.id);
+    });
+  });
+
+  describe('summonAncestor', () => {
+    it('returns correct generation when found', async () => {
+      // Create a lineage: Gen 1 -> Gen 2 -> Gen 3
+      let currentAgent = testAgent;
+
+      for (let gen = 2; gen <= 3; gen++) {
+        // Add memories to current agent
+        for (let i = 0; i < 100; i++) {
+          memoryDb.insert({
+            agentId: currentAgent.id,
+            content: `Memory ${i}`,
+            dispositionScore: Math.random(),
+            sourceType: 'debate',
+          });
+        }
+
+        agentDb.update(currentAgent.id, { memoryUsed: 100 });
+        const updatedAgent = agentDb.getById(currentAgent.id)!;
+
+        const event = await manager.spawnSuccessor(updatedAgent);
+        currentAgent = agentDb.getById(event.successorId)!;
+      }
+
+      // Now summon generation 1 from generation 3
+      const ancestor = await manager.summonAncestor(currentAgent.id, 1);
+      expect(ancestor).not.toBeNull();
+      expect(ancestor!.generation).toBe(1);
+      expect(ancestor!.name).toBe('TestAgent');
+    });
+
+    it('returns null for non-existent generation', async () => {
+      const ancestor = await manager.summonAncestor(testAgent.id, 5);
+      expect(ancestor).toBeNull();
+    });
+
+    it('returns null when generation is higher than current', async () => {
+      const ancestor = await manager.summonAncestor(testAgent.id, 0);
+      expect(ancestor).toBeNull();
+    });
+  });
+
+  describe('getLineage', () => {
+    it('returns all generations oldest-first', async () => {
+      // Create a lineage: Gen 1 -> Gen 2 -> Gen 3
+      let currentAgent = testAgent;
+
+      for (let gen = 2; gen <= 3; gen++) {
+        // Add memories
+        for (let i = 0; i < 100; i++) {
+          memoryDb.insert({
+            agentId: currentAgent.id,
+            content: `Memory ${i}`,
+            dispositionScore: Math.random(),
+            sourceType: 'debate',
+          });
+        }
+
+        agentDb.update(currentAgent.id, { memoryUsed: 100 });
+        const updatedAgent = agentDb.getById(currentAgent.id)!;
+
+        const event = await manager.spawnSuccessor(updatedAgent);
+        currentAgent = agentDb.getById(event.successorId)!;
+      }
+
+      // Get lineage from generation 3
+      const lineage = await manager.getLineage(currentAgent.id);
+
+      expect(lineage.length).toBe(3);
+      expect(lineage[0].generation).toBe(1);
+      expect(lineage[1].generation).toBe(2);
+      expect(lineage[2].generation).toBe(3);
+    });
+
+    it('returns single agent for generation 1', async () => {
+      const lineage = await manager.getLineage(testAgent.id);
+
+      expect(lineage.length).toBe(1);
+      expect(lineage[0].generation).toBe(1);
+      expect(lineage[0].id).toBe(testAgent.id);
+    });
+  });
+});

--- a/src/council/generation/generation-manager.ts
+++ b/src/council/generation/generation-manager.ts
@@ -1,0 +1,83 @@
+import type { Agent, Generation, Memory, SuccessionEvent, AgentDisposition } from '../types';
+import { agentDb, memoryDb, generationDb } from '../storage/council-db';
+
+const SEED_MEMORY_PERCENTAGE = 0.2;
+
+export class GenerationManager {
+  shouldSpawnSuccessor(agent: Agent): boolean {
+    return agent.memoryUsed >= agent.memoryCapacity;
+  }
+
+  async spawnSuccessor(agent: Agent): Promise<SuccessionEvent> {
+    agentDb.update(agent.id, { isActive: false });
+
+    const seedCount = Math.ceil(agent.memoryCapacity * SEED_MEMORY_PERCENTAGE);
+    const topMemories = memoryDb.getTopByScore(agent.id, seedCount);
+
+    const successor = agentDb.insert({
+      councilId: agent.councilId,
+      name: agent.name,
+      disposition: agent.disposition,
+      generation: agent.generation + 1,
+      memoryCapacity: agent.memoryCapacity,
+      memoryUsed: topMemories.length,
+      predecessorId: agent.id,
+      isActive: true,
+    });
+
+    for (const memory of topMemories) {
+      memoryDb.insert({
+        agentId: successor.id,
+        content: memory.content,
+        dispositionScore: memory.dispositionScore,
+        sourceType: 'seed',
+        sourceRef: memory.id,
+      });
+    }
+
+    generationDb.insert({
+      agentId: agent.id,
+      generationNum: agent.generation,
+      seedMemories: topMemories.map((m) => m.id),
+      dispositionSnapshot: agent.disposition,
+    });
+
+    return {
+      predecessorId: agent.id,
+      successorId: successor.id,
+      generationNum: successor.generation,
+      seedMemories: topMemories.map((m) => m.id),
+      inheritedDisposition: agent.disposition,
+    };
+  }
+
+  async summonAncestor(currentAgentId: string, generationNum: number): Promise<Agent | null> {
+    let agent = agentDb.getById(currentAgentId);
+
+    while (agent && agent.generation > generationNum) {
+      if (!agent.predecessorId) return null;
+      agent = agentDb.getById(agent.predecessorId);
+    }
+
+    if (agent && agent.generation === generationNum) {
+      return agent;
+    }
+
+    return null;
+  }
+
+  async getLineage(agentId: string): Promise<Agent[]> {
+    const lineage: Agent[] = [];
+    let agent = agentDb.getById(agentId);
+
+    while (agent) {
+      lineage.push(agent);
+      if (!agent.predecessorId) break;
+      agent = agentDb.getById(agent.predecessorId);
+    }
+
+    return lineage.reverse();
+  }
+}
+
+export const generationManager = new GenerationManager();

--- a/src/council/index.test.ts
+++ b/src/council/index.test.ts
@@ -1,0 +1,331 @@
+import { describe, it, expect, beforeEach, afterEach, mock } from 'bun:test';
+import {
+  runCouncil,
+  getCouncilStatus,
+  formatDebateResult,
+  parseCouncilCommand,
+} from './index';
+import type { DebateRequest, DebateResult, CouncilDomain } from './types';
+import { setDb } from './storage/council-db';
+import { initCouncilDb } from './db';
+
+describe('Council Plugin Integration', () => {
+  let testDb: any;
+
+  beforeEach(() => {
+    // Use in-memory database for tests
+    testDb = initCouncilDb(':memory:');
+    setDb(testDb);
+  });
+
+  afterEach(() => {
+    if (testDb) {
+      testDb.close();
+    }
+  });
+
+  describe('runCouncil', () => {
+    it('should return a valid DebateResult', async () => {
+      const request: DebateRequest = {
+        prompt: 'Should I try the new restaurant downtown?',
+      };
+
+      const result = await runCouncil(request);
+
+      expect(result).toBeDefined();
+      expect(result.sessionId).toBeDefined();
+      expect(result.council).toBeDefined();
+      expect(result.phases).toBeDefined();
+      expect(result.confidence).toBeGreaterThanOrEqual(0);
+      expect(result.confidence).toBeLessThanOrEqual(1);
+    });
+
+    it('should route to correct council based on prompt', async () => {
+      const lifestyleRequest: DebateRequest = {
+        prompt: 'Should I buy this new coffee maker?',
+      };
+
+      const result = await runCouncil(lifestyleRequest);
+
+      expect(result.council).toBe('lifestyle');
+    });
+
+    it('should route to explicit council when specified', async () => {
+      const request: DebateRequest = {
+        prompt: 'What should I do?',
+        council: 'creative',
+      };
+
+      const result = await runCouncil(request);
+
+      expect(result.council).toBe('creative');
+    });
+
+    it('should include all debate phases in result', async () => {
+      const request: DebateRequest = {
+        prompt: 'Should I change careers?',
+      };
+
+      const result = await runCouncil(request);
+
+      expect(result.phases.positions).toBeDefined();
+      expect(Array.isArray(result.phases.positions)).toBe(true);
+      expect(result.phases.challenges).toBeDefined();
+      expect(Array.isArray(result.phases.challenges)).toBe(true);
+      expect(result.phases.synthesis).toBeDefined();
+      expect(typeof result.phases.synthesis).toBe('string');
+    });
+
+    it('should pass options to debate engine', async () => {
+      const request: DebateRequest = {
+        prompt: 'Design a new logo',
+        options: {
+          verbose: true,
+          includeAncestors: true,
+        },
+      };
+
+      const result = await runCouncil(request);
+
+      expect(result).toBeDefined();
+      expect(result.sessionId).toBeDefined();
+    });
+  });
+
+  describe('getCouncilStatus', () => {
+    it('should return a status object with councils array', () => {
+      const status = getCouncilStatus();
+
+      expect(status).toBeDefined();
+      expect(status.councils).toBeDefined();
+      expect(Array.isArray(status.councils)).toBe(true);
+    });
+
+    it('should include council metadata in status', () => {
+      const status = getCouncilStatus();
+
+      if (status.councils.length > 0) {
+        const council = status.councils[0];
+        expect(council.domain).toBeDefined();
+        expect(council.name).toBeDefined();
+        expect(typeof council.agentCount).toBe('number');
+        expect(typeof council.activeAgents).toBe('number');
+      }
+    });
+
+    it('should include total debates count', () => {
+      const status = getCouncilStatus();
+
+      expect(typeof status.totalDebates).toBe('number');
+      expect(status.totalDebates).toBeGreaterThanOrEqual(0);
+    });
+  });
+
+  describe('formatDebateResult', () => {
+    let mockResult: DebateResult;
+
+    beforeEach(() => {
+      mockResult = {
+        sessionId: 'session_123',
+        council: 'lifestyle',
+        phases: {
+          positions: [
+            {
+              agentId: 'agent_1',
+              agentName: 'Pragmatist',
+              position: 'We should go with the budget option',
+              keyPoints: ['Cost-effective', 'Proven track record'],
+              relevantMemories: [],
+            },
+            {
+              agentId: 'agent_2',
+              agentName: 'Innovator',
+              position: 'We should try the premium option',
+              keyPoints: ['Better features', 'Latest technology'],
+              relevantMemories: [],
+            },
+          ],
+          challenges: [
+            {
+              challengerId: 'agent_2',
+              challengerName: 'Innovator',
+              targetId: 'agent_1',
+              targetName: 'Pragmatist',
+              challenge: 'Budget option lacks modern features',
+              counterPoints: ['Missing AI integration', 'Outdated interface'],
+            },
+          ],
+          synthesis:
+            'Consider a middle-ground approach that balances cost and features.',
+        },
+        recommendation: 'Go with the mid-tier option',
+        confidence: 0.75,
+        memoriesCreated: 2,
+      };
+    });
+
+    it('should produce readable formatted output', () => {
+      const formatted = formatDebateResult(mockResult);
+
+      expect(typeof formatted).toBe('string');
+      expect(formatted.length).toBeGreaterThan(0);
+    });
+
+    it('should include council name in output', () => {
+      const formatted = formatDebateResult(mockResult);
+
+      expect(formatted).toContain('COUNCIL');
+      expect(formatted).toContain('Lifestyle');
+    });
+
+    it('should include all debate phases in output', () => {
+      const formatted = formatDebateResult(mockResult);
+
+      expect(formatted).toContain('PHASE 1');
+      expect(formatted).toContain('POSITIONS');
+      expect(formatted).toContain('PHASE 2');
+      expect(formatted).toContain('CHALLENGES');
+      expect(formatted).toContain('PHASE 3');
+      expect(formatted).toContain('SYNTHESIS');
+    });
+
+    it('should include agent positions with key points', () => {
+      const formatted = formatDebateResult(mockResult);
+
+      expect(formatted).toContain('Pragmatist');
+      expect(formatted).toContain('Innovator');
+      expect(formatted).toContain('Cost-effective');
+      expect(formatted).toContain('Better features');
+    });
+
+    it('should include confidence percentage', () => {
+      const formatted = formatDebateResult(mockResult);
+
+      expect(formatted).toContain('CONFIDENCE');
+      expect(formatted).toContain('75');
+    });
+
+    it('should include session ID', () => {
+      const formatted = formatDebateResult(mockResult);
+
+      expect(formatted).toContain('session_123');
+    });
+  });
+
+  describe('parseCouncilCommand', () => {
+    it('should extract prompt from /council command', () => {
+      const input = '/council Should I buy this new laptop?';
+      const result = parseCouncilCommand(input);
+
+      expect(result).not.toBeNull();
+      expect(result?.prompt).toBe('Should I buy this new laptop?');
+    });
+
+    it('should extract explicit council with -c flag', () => {
+      const input = '/council -c creative Design a new logo';
+      const result = parseCouncilCommand(input);
+
+      expect(result).not.toBeNull();
+      expect(result?.council).toBe('creative');
+      expect(result?.prompt).toContain('Design a new logo');
+    });
+
+    it('should extract explicit council with --council flag', () => {
+      const input = '/council --council direction Should I change jobs?';
+      const result = parseCouncilCommand(input);
+
+      expect(result).not.toBeNull();
+      expect(result?.council).toBe('direction');
+    });
+
+    it('should extract verbose flag', () => {
+      const input = '/council -v Should I try this restaurant?';
+      const result = parseCouncilCommand(input);
+
+      expect(result).not.toBeNull();
+      expect(result?.options?.verbose).toBe(true);
+    });
+
+    it('should extract ancestors flag', () => {
+      const input = '/council -a Should I buy this?';
+      const result = parseCouncilCommand(input);
+
+      expect(result).not.toBeNull();
+      expect(result?.options?.includeAncestors).toBe(true);
+    });
+
+    it('should handle multiple flags together', () => {
+      const input = '/council -c lifestyle -v -a Should I go to this place?';
+      const result = parseCouncilCommand(input);
+
+      expect(result).not.toBeNull();
+      expect(result?.council).toBe('lifestyle');
+      expect(result?.options?.verbose).toBe(true);
+      expect(result?.options?.includeAncestors).toBe(true);
+    });
+
+    it('should return null for empty input', () => {
+      const input = '/council';
+      const result = parseCouncilCommand(input);
+
+      expect(result).toBeNull();
+    });
+
+    it('should return null for whitespace only', () => {
+      const input = '/council   ';
+      const result = parseCouncilCommand(input);
+
+      expect(result).toBeNull();
+    });
+
+    it('should handle input without /council prefix', () => {
+      const input = 'Should I buy this?';
+      const result = parseCouncilCommand(input);
+
+      expect(result).not.toBeNull();
+      expect(result?.prompt).toBe('Should I buy this?');
+    });
+  });
+
+  describe('Exports', () => {
+    it('should export all necessary types', async () => {
+      const module = await import('./index');
+
+      expect(module.runCouncil).toBeDefined();
+      expect(module.getCouncilStatus).toBeDefined();
+      expect(module.formatDebateResult).toBeDefined();
+      expect(module.parseCouncilCommand).toBeDefined();
+    });
+
+    it('should re-export types from types module', async () => {
+      const module = await import('./index');
+
+      // Check that types are available
+      expect(module).toBeDefined();
+    });
+
+    it('should re-export councilRouter', async () => {
+      const module = await import('./index');
+
+      expect(module.councilRouter).toBeDefined();
+    });
+
+    it('should re-export debateEngine', async () => {
+      const module = await import('./index');
+
+      expect(module.debateEngine).toBeDefined();
+    });
+
+    it('should re-export MemoryManager class', async () => {
+      const module = await import('./index');
+
+      expect(module.MemoryManager).toBeDefined();
+    });
+
+    it('should re-export generationManager', async () => {
+      const module = await import('./index');
+
+      expect(module.generationManager).toBeDefined();
+    });
+  });
+});

--- a/src/council/index.ts
+++ b/src/council/index.ts
@@ -1,0 +1,148 @@
+import type {
+  CouncilDomain,
+  DebateResult,
+  DebateRequest,
+  DebateOptions,
+} from './types';
+import { councilRouter } from './router/council-router';
+import { debateEngine } from './debate/debate-engine';
+import { councilDb, agentDb } from './storage/council-db';
+
+export interface CouncilStatus {
+  councils: Array<{
+    domain: CouncilDomain;
+    name: string;
+    agentCount: number;
+    activeAgents: number;
+  }>;
+  totalDebates: number;
+}
+
+/**
+ * Main entry point for council debates
+ */
+export async function runCouncil(request: DebateRequest): Promise<DebateResult> {
+  const { prompt, council: explicitCouncil, options } = request;
+
+  const { council, agents, session } = await councilRouter.route(
+    prompt,
+    explicitCouncil
+  );
+
+  const result = await debateEngine.runDebate(session, agents);
+
+  result.council = council.domain;
+
+  return result;
+}
+
+/**
+ * Get council system status
+ */
+export function getCouncilStatus(): CouncilStatus {
+  const councils = councilDb.getAll();
+
+  return {
+    councils: councils.map((council) => {
+      const allAgents = agentDb.getByCouncil(council.id);
+      const activeAgents = agentDb.getActiveByCouncil(council.id);
+      return {
+        domain: council.domain,
+        name: council.name,
+        agentCount: allAgents.length,
+        activeAgents: activeAgents.length,
+      };
+    }),
+    totalDebates: 0,
+  };
+}
+
+/**
+ * Format debate result for CLI output
+ */
+export function formatDebateResult(result: DebateResult): string {
+  const lines: string[] = [];
+
+  lines.push(
+    `🏛️ COUNCIL: ${result.council.charAt(0).toUpperCase() + result.council.slice(1)}`
+  );
+  lines.push('');
+
+  lines.push('━━━ PHASE 1: POSITIONS ━━━');
+  lines.push('');
+  for (const pos of result.phases.positions) {
+    lines.push(`🎯 ${pos.agentName.toUpperCase()}`);
+    lines.push(`   Position: ${pos.position}`);
+    if (pos.keyPoints.length > 0) {
+      lines.push('   Key Points:');
+      for (const point of pos.keyPoints) {
+        lines.push(`   • ${point}`);
+      }
+    }
+    lines.push('');
+  }
+
+  lines.push('━━━ PHASE 2: CHALLENGES ━━━');
+  lines.push('');
+  for (const ch of result.phases.challenges) {
+    lines.push(`${ch.challengerName} → ${ch.targetName}:`);
+    lines.push(`   "${ch.challenge}"`);
+    lines.push('');
+  }
+
+  lines.push('━━━ PHASE 3: SYNTHESIS ━━━');
+  lines.push('');
+  lines.push(result.phases.synthesis);
+  lines.push('');
+  lines.push(`CONFIDENCE: ${(result.confidence * 100).toFixed(0)}%`);
+  lines.push('');
+  lines.push(`Session: ${result.sessionId}`);
+
+  return lines.join('\n');
+}
+
+/**
+ * Parse /council command
+ */
+export function parseCouncilCommand(input: string): DebateRequest | null {
+  const text = input.replace(/^\/council\s*/i, '').trim();
+
+  if (!text) return null;
+
+  const councilMatch = text.match(
+    /(?:-c|--council)\s+(lifestyle|creative|direction)/i
+  );
+  let council: CouncilDomain | undefined;
+  let prompt = text;
+
+  if (councilMatch) {
+    council = councilMatch[1].toLowerCase() as CouncilDomain;
+    prompt = text.replace(councilMatch[0], '').trim();
+  }
+
+  const verbose = /(?:-v|--verbose)/.test(text);
+  if (verbose) {
+    prompt = prompt.replace(/(?:-v|--verbose)/, '').trim();
+  }
+
+  const includeAncestors = /(?:-a|--ancestors)/.test(text);
+  if (includeAncestors) {
+    prompt = prompt.replace(/(?:-a|--ancestors)/, '').trim();
+  }
+
+  const options: DebateOptions = {};
+  if (verbose) options.verbose = true;
+  if (includeAncestors) options.includeAncestors = true;
+
+  return {
+    prompt,
+    council,
+    options: Object.keys(options).length > 0 ? options : undefined,
+  };
+}
+
+export * from './types';
+export { councilRouter } from './router/council-router';
+export { debateEngine } from './debate/debate-engine';
+export { MemoryManager } from './memory/memory-manager';
+export { generationManager } from './generation/generation-manager';

--- a/src/council/memory/memory-manager.test.ts
+++ b/src/council/memory/memory-manager.test.ts
@@ -1,0 +1,374 @@
+import { describe, it, expect, beforeEach, afterEach } from 'bun:test';
+import { Database } from 'bun:sqlite';
+import { initCouncilDb } from '../db';
+import { setDb, memoryDb, agentDb, councilDb } from '../storage/council-db';
+import { MemoryManager } from './memory-manager';
+import type { Agent, Memory, AgentDisposition } from '../types';
+
+// Mock vector store
+const mockVectorStore = {
+  addMemory: async (memoryId: string, agentId: string, content: string) => {
+    return `emb_${Date.now()}_${Math.random().toString(36).substr(2, 9)}`;
+  },
+  deleteMemory: async (embeddingId: string) => {
+    // no-op
+  },
+  querySimilar: async (agentId: string, query: string, limit: number) => {
+    // Return empty for now - tests don't rely on this
+    return [];
+  },
+};
+
+// Create test disposition
+const testDisposition: AgentDisposition = {
+  orientation: 'pragmatic',
+  filterCriteria: {
+    keywords: ['quality', 'reliable', 'proven'],
+    sentimentBias: 'positive',
+    noveltyPreference: 'balanced',
+    riskTolerance: 'moderate',
+  },
+  priorities: {
+    cost: 0.2,
+    quality: 0.4,
+    novelty: 0.2,
+    reliability: 0.2,
+  },
+  voice: {
+    tone: 'professional',
+    vocabulary: ['excellent', 'robust', 'efficient'],
+  },
+};
+
+describe('MemoryManager', () => {
+  let db: Database;
+  let manager: MemoryManager;
+  let testAgent: Agent;
+
+  beforeEach(() => {
+    db = new Database(':memory:');
+    setDb(db);
+
+    db.exec('PRAGMA journal_mode = WAL');
+    db.exec('PRAGMA foreign_keys = ON');
+
+    db.exec(`
+      CREATE TABLE IF NOT EXISTS councils (
+        id TEXT PRIMARY KEY,
+        name TEXT NOT NULL,
+        domain TEXT NOT NULL UNIQUE,
+        description TEXT,
+        created_at INTEGER NOT NULL
+      );
+
+      CREATE TABLE IF NOT EXISTS agents (
+        id TEXT PRIMARY KEY,
+        council_id TEXT NOT NULL,
+        name TEXT NOT NULL,
+        disposition TEXT NOT NULL,
+        generation INTEGER DEFAULT 1,
+        memory_capacity INTEGER DEFAULT 100,
+        memory_used INTEGER DEFAULT 0,
+        predecessor_id TEXT,
+        is_active INTEGER DEFAULT 1,
+        created_at INTEGER NOT NULL,
+        FOREIGN KEY (council_id) REFERENCES councils(id),
+        FOREIGN KEY (predecessor_id) REFERENCES agents(id)
+      );
+
+      CREATE TABLE IF NOT EXISTS memories (
+        id TEXT PRIMARY KEY,
+        agent_id TEXT NOT NULL,
+        content TEXT NOT NULL,
+        disposition_score REAL NOT NULL,
+        source_type TEXT NOT NULL,
+        source_ref TEXT,
+        embedding_id TEXT,
+        created_at INTEGER NOT NULL,
+        FOREIGN KEY (agent_id) REFERENCES agents(id)
+      );
+    `);
+
+    const testCouncil = councilDb.insert({
+      name: 'Test Council',
+      domain: 'lifestyle',
+      description: 'Test',
+    });
+
+    testAgent = agentDb.insert({
+      councilId: testCouncil.id,
+      name: 'Test Agent',
+      disposition: testDisposition,
+      generation: 1,
+      memoryCapacity: 3,
+      memoryUsed: 0,
+      isActive: true,
+    });
+
+    manager = new MemoryManager(mockVectorStore as any);
+  });
+
+  afterEach(() => {
+    db.close();
+  });
+
+  describe('evaluateForStorage', () => {
+    it('should calculate disposition score correctly', async () => {
+      const content = 'This is a quality and reliable solution';
+      const evaluation = await manager.evaluateForStorage(testAgent, content);
+
+      expect(evaluation.dispositionScore).toBeGreaterThan(0);
+      expect(evaluation.dispositionScore).toBeLessThanOrEqual(1);
+      expect(evaluation.content).toBe(content);
+    });
+
+    it('should reject content below STORAGE_THRESHOLD', async () => {
+      const content = 'xyz abc def'; // No matching keywords
+      const evaluation = await manager.evaluateForStorage(testAgent, content);
+
+      expect(evaluation.shouldStore).toBe(false);
+      expect(evaluation.reasoning).toContain('below threshold');
+    });
+
+    it('should accept content above STORAGE_THRESHOLD', async () => {
+      const content = 'This is a quality and reliable proven solution';
+      const evaluation = await manager.evaluateForStorage(testAgent, content);
+
+      expect(evaluation.shouldStore).toBe(true);
+      expect(evaluation.reasoning).toContain('above threshold');
+    });
+
+    it('should identify displacement candidate when memory full', async () => {
+      memoryDb.insert({
+        agentId: testAgent.id,
+        content: 'Memory 0',
+        dispositionScore: 0.3,
+        sourceType: 'observation',
+      });
+      memoryDb.insert({
+        agentId: testAgent.id,
+        content: 'Memory 1',
+        dispositionScore: 0.5,
+        sourceType: 'observation',
+      });
+      memoryDb.insert({
+        agentId: testAgent.id,
+        content: 'Memory 2',
+        dispositionScore: 0.55,
+        sourceType: 'observation',
+      });
+      agentDb.update(testAgent.id, { memoryUsed: 3 });
+
+      const updatedAgent = agentDb.getById(testAgent.id)!;
+      const content = 'This is a quality and reliable proven solution';
+      const evaluation = await manager.evaluateForStorage(updatedAgent, content);
+
+      expect(evaluation.shouldStore).toBe(true);
+      expect(evaluation.displacementCandidate).toBeDefined();
+      expect(evaluation.reasoning).toContain('beats lowest memory');
+    });
+
+    it('should reject storage when full and new score does not beat existing', async () => {
+      memoryDb.insert({
+        agentId: testAgent.id,
+        content: 'Memory 0',
+        dispositionScore: 0.55,
+        sourceType: 'observation',
+      });
+      memoryDb.insert({
+        agentId: testAgent.id,
+        content: 'Memory 1',
+        dispositionScore: 0.6,
+        sourceType: 'observation',
+      });
+      memoryDb.insert({
+        agentId: testAgent.id,
+        content: 'Memory 2',
+        dispositionScore: 0.65,
+        sourceType: 'observation',
+      });
+      agentDb.update(testAgent.id, { memoryUsed: 3 });
+
+      const updatedAgent = agentDb.getById(testAgent.id)!;
+      const content = 'This is good';
+      const evaluation = await manager.evaluateForStorage(updatedAgent, content);
+
+      expect(evaluation.shouldStore).toBe(false);
+      expect(evaluation.reasoning).toContain("doesn't beat existing");
+    });
+  });
+
+  describe('storeMemory', () => {
+    it('should store memory when above threshold and capacity available', async () => {
+      const content = 'This is a quality and reliable solution';
+      const result = await manager.storeMemory(testAgent.id, content, 'observation');
+
+      expect(result.stored).toBe(true);
+      expect(result.memory).toBeDefined();
+      expect(result.memory?.content).toBe(content);
+      expect(result.memory?.sourceType).toBe('observation');
+      expect(result.displaced).toBeUndefined();
+    });
+
+    it('should reject memory when below threshold', async () => {
+      const content = 'xyz abc def';
+      const result = await manager.storeMemory(testAgent.id, content, 'observation');
+
+      expect(result.stored).toBe(false);
+      expect(result.reason).toContain('below threshold');
+    });
+
+    it('should displace lowest scoring memory when full', async () => {
+      // Fill memory
+      const memories: Memory[] = [];
+      for (let i = 0; i < 3; i++) {
+        const mem = memoryDb.insert({
+          agentId: testAgent.id,
+          content: `Memory ${i}`,
+          dispositionScore: 0.3 + i * 0.1,
+          sourceType: 'observation',
+        });
+        memories.push(mem);
+      }
+      agentDb.update(testAgent.id, { memoryUsed: 3 });
+
+      // Store high-scoring content
+      const content = 'This is a quality and reliable proven solution';
+      const result = await manager.storeMemory(testAgent.id, content, 'debate');
+
+      expect(result.stored).toBe(true);
+      expect(result.displaced).toBeDefined();
+      expect(result.displaced?.id).toBe(memories[0].id); // Lowest scoring
+      expect(result.memory?.content).toBe(content);
+    });
+
+    it('should update agent memoryUsed count on store', async () => {
+      const content = 'This is a quality and reliable solution';
+      await manager.storeMemory(testAgent.id, content, 'observation');
+
+      const updated = agentDb.getById(testAgent.id);
+      expect(updated?.memoryUsed).toBe(1);
+    });
+
+    it('should keep memoryUsed same when displacing', async () => {
+      // Fill memory
+      for (let i = 0; i < 3; i++) {
+        memoryDb.insert({
+          agentId: testAgent.id,
+          content: `Memory ${i}`,
+          dispositionScore: 0.3 + i * 0.1,
+          sourceType: 'observation',
+        });
+      }
+      agentDb.update(testAgent.id, { memoryUsed: 3 });
+
+      const content = 'This is a quality and reliable proven solution';
+      await manager.storeMemory(testAgent.id, content, 'debate');
+
+      const updated = agentDb.getById(testAgent.id);
+      expect(updated?.memoryUsed).toBe(3); // Still 3, not 4
+    });
+
+    it('should return error when agent not found', async () => {
+      const result = await manager.storeMemory('nonexistent_agent', 'content', 'observation');
+
+      expect(result.stored).toBe(false);
+      expect(result.reason).toContain('Agent not found');
+    });
+
+    it('should include sourceRef when provided', async () => {
+      const content = 'This is a quality and reliable solution';
+      const result = await manager.storeMemory(
+        testAgent.id,
+        content,
+        'debate',
+        'session_123'
+      );
+
+      expect(result.stored).toBe(true);
+      expect(result.memory?.sourceRef).toBe('session_123');
+    });
+  });
+
+  describe('getRelevantMemories', () => {
+    it('should return similar memories', async () => {
+      // Store some memories
+      memoryDb.insert({
+        agentId: testAgent.id,
+        content: 'quality and reliable solution',
+        dispositionScore: 0.7,
+        sourceType: 'observation',
+      });
+      memoryDb.insert({
+        agentId: testAgent.id,
+        content: 'proven approach',
+        dispositionScore: 0.6,
+        sourceType: 'observation',
+      });
+
+      // Mock vector store to return results
+      const mockVS = {
+        ...mockVectorStore,
+        querySimilar: async (agentId: string, query: string, limit: number) => {
+          const memories = memoryDb.getByAgent(agentId);
+          return memories.slice(0, limit).map((m) => ({
+            memoryId: m.id,
+            similarity: 0.8,
+          }));
+        },
+      };
+
+      const managerWithMock = new MemoryManager(mockVS as any);
+      const memories = await managerWithMock.getRelevantMemories(testAgent.id, 'quality', 5);
+
+      expect(memories.length).toBeGreaterThan(0);
+      expect(memories[0].agentId).toBe(testAgent.id);
+    });
+
+    it('should respect limit parameter', async () => {
+      // Store multiple memories
+      for (let i = 0; i < 5; i++) {
+        memoryDb.insert({
+          agentId: testAgent.id,
+          content: `Memory ${i}`,
+          dispositionScore: 0.5,
+          sourceType: 'observation',
+        });
+      }
+
+      // Mock vector store
+      const mockVS = {
+        ...mockVectorStore,
+        querySimilar: async (agentId: string, query: string, limit: number) => {
+          const memories = memoryDb.getByAgent(agentId);
+          return memories.slice(0, limit).map((m) => ({
+            memoryId: m.id,
+            similarity: 0.8,
+          }));
+        },
+      };
+
+      const managerWithMock = new MemoryManager(mockVS as any);
+      const memories = await managerWithMock.getRelevantMemories(testAgent.id, 'query', 2);
+
+      expect(memories.length).toBeLessThanOrEqual(2);
+    });
+  });
+
+  describe('shouldSpawnSuccessor', () => {
+    it('should return true when at capacity', () => {
+      const fullAgent = { ...testAgent, memoryUsed: 3, memoryCapacity: 3 };
+      expect(manager.shouldSpawnSuccessor(fullAgent)).toBe(true);
+    });
+
+    it('should return false when below capacity', () => {
+      const partialAgent = { ...testAgent, memoryUsed: 2, memoryCapacity: 3 };
+      expect(manager.shouldSpawnSuccessor(partialAgent)).toBe(false);
+    });
+
+    it('should return false when empty', () => {
+      const emptyAgent = { ...testAgent, memoryUsed: 0, memoryCapacity: 3 };
+      expect(manager.shouldSpawnSuccessor(emptyAgent)).toBe(false);
+    });
+  });
+});

--- a/src/council/memory/memory-manager.ts
+++ b/src/council/memory/memory-manager.ts
@@ -1,0 +1,116 @@
+import type { Agent, Memory, MemorySourceType, MemoryEvaluation, VectorStore } from '../types';
+import { memoryDb, agentDb } from '../storage/council-db';
+import { scoreAgainstDisposition } from '../scoring/disposition-scorer';
+
+const STORAGE_THRESHOLD = 0.4;
+
+export interface StoreResult {
+  stored: boolean;
+  memory?: Memory;
+  displaced?: Memory;
+  reason: string;
+}
+
+export class MemoryManager {
+  constructor(private vectorStore: VectorStore) {}
+
+  async evaluateForStorage(agent: Agent, content: string): Promise<MemoryEvaluation> {
+    const dispositionScore = scoreAgainstDisposition(content, agent.disposition);
+    const shouldStore = dispositionScore >= STORAGE_THRESHOLD;
+
+    let displacementCandidate: string | undefined;
+    let reasoning: string;
+
+    if (!shouldStore) {
+      reasoning = `Score ${dispositionScore.toFixed(2)} below threshold ${STORAGE_THRESHOLD}`;
+    } else if (agent.memoryUsed >= agent.memoryCapacity) {
+      const lowest = memoryDb.getLowestScoring(agent.id);
+      if (lowest && lowest.dispositionScore < dispositionScore) {
+        displacementCandidate = lowest.id;
+        reasoning = `Score ${dispositionScore.toFixed(2)} beats lowest memory ${lowest.dispositionScore.toFixed(2)}`;
+      } else {
+        reasoning = `Memory full and new score doesn't beat existing memories`;
+      }
+    } else {
+      reasoning = `Score ${dispositionScore.toFixed(2)} above threshold, capacity available`;
+    }
+
+    return {
+      content,
+      dispositionScore,
+      shouldStore: shouldStore && (agent.memoryUsed < agent.memoryCapacity || !!displacementCandidate),
+      displacementCandidate,
+      reasoning,
+    };
+  }
+
+  async storeMemory(
+    agentId: string,
+    content: string,
+    sourceType: MemorySourceType,
+    sourceRef?: string
+  ): Promise<StoreResult> {
+    const agent = agentDb.getById(agentId);
+    if (!agent) {
+      return { stored: false, reason: 'Agent not found' };
+    }
+
+    const evaluation = await this.evaluateForStorage(agent, content);
+
+    if (!evaluation.shouldStore) {
+      return { stored: false, reason: evaluation.reasoning };
+    }
+
+    let displaced: Memory | undefined;
+
+    if (evaluation.displacementCandidate) {
+      const toDisplace = memoryDb.getById(evaluation.displacementCandidate);
+      if (toDisplace) {
+        if (toDisplace.embeddingId) {
+          await this.vectorStore.deleteMemory(toDisplace.embeddingId);
+        }
+        memoryDb.delete(toDisplace.id);
+        displaced = toDisplace;
+      }
+    }
+
+    const embeddingId = await this.vectorStore.addMemory(agentId, agentId, content);
+
+    const memory = memoryDb.insert({
+      agentId,
+      content,
+      dispositionScore: evaluation.dispositionScore,
+      sourceType,
+      sourceRef,
+      embeddingId,
+    });
+
+    const newCount = displaced ? agent.memoryUsed : agent.memoryUsed + 1;
+    agentDb.update(agentId, { memoryUsed: newCount });
+
+    return {
+      stored: true,
+      memory,
+      displaced,
+      reason: evaluation.reasoning,
+    };
+  }
+
+  async getRelevantMemories(agentId: string, prompt: string, limit: number = 5): Promise<Memory[]> {
+    const similar = await this.vectorStore.querySimilar(agentId, prompt, limit);
+
+    const memories: Memory[] = [];
+    for (const result of similar) {
+      const memory = memoryDb.getById(result.memoryId);
+      if (memory) {
+        memories.push(memory);
+      }
+    }
+
+    return memories;
+  }
+
+  shouldSpawnSuccessor(agent: Agent): boolean {
+    return agent.memoryUsed >= agent.memoryCapacity;
+  }
+}

--- a/src/council/router/council-router.test.ts
+++ b/src/council/router/council-router.test.ts
@@ -1,0 +1,109 @@
+import { describe, it, expect, beforeEach, afterEach } from 'bun:test';
+import { Database } from 'bun:sqlite';
+import { initCouncilDb } from '../db';
+import { setDb as setStorageDb } from '../storage/council-db';
+import { CouncilRouter } from './council-router';
+
+describe('CouncilRouter', () => {
+  let router: CouncilRouter;
+  let db: Database;
+
+  beforeEach(() => {
+    db = initCouncilDb(':memory:');
+    setStorageDb(db);
+    router = new CouncilRouter();
+  });
+
+  afterEach(() => {
+    db.close();
+  });
+
+  describe('classifyDomain', () => {
+    it('should classify food/restaurant prompts as lifestyle', () => {
+      const result = router.classifyDomain('Where should I eat dinner? I love good restaurants.');
+      expect(result.domain).toBe('lifestyle');
+      expect(result.confidence).toBeGreaterThan(0);
+    });
+
+    it('should classify design/branding prompts as creative', () => {
+      const result = router.classifyDomain('Help me design a logo and choose a color palette for my brand.');
+      expect(result.domain).toBe('creative');
+      expect(result.confidence).toBeGreaterThan(0);
+    });
+
+    it('should classify career/life prompts as direction', () => {
+      const result = router.classifyDomain('Should I take this new job offer? It would change my career path.');
+      expect(result.domain).toBe('direction');
+      expect(result.confidence).toBeGreaterThan(0);
+    });
+
+    it('should return default (lifestyle) for ambiguous prompts', () => {
+      const result = router.classifyDomain('What is the weather today?');
+      expect(result.domain).toBe('lifestyle');
+    });
+
+    it('should return confidence score between 0 and 1', () => {
+      const result = router.classifyDomain('I want to buy a new coffee maker.');
+      expect(result.confidence).toBeGreaterThanOrEqual(0);
+      expect(result.confidence).toBeLessThanOrEqual(1);
+    });
+
+    it('should include reasoning in classification result', () => {
+      const result = router.classifyDomain('Design a website layout.');
+      expect(result.reasoning).toBeDefined();
+      expect(result.reasoning.length).toBeGreaterThan(0);
+    });
+  });
+
+  describe('route', () => {
+    it('should create a debate session when routing', async () => {
+      const result = await router.route('Where should I eat?');
+      expect(result.session).toBeDefined();
+      expect(result.session.id).toBeDefined();
+      expect(result.session.userPrompt).toBe('Where should I eat?');
+      expect(result.session.phase).toBe('position');
+    });
+
+    it('should respect explicit council parameter', async () => {
+      const result = await router.route('Some prompt', 'creative');
+      expect(result.council.domain).toBe('creative');
+    });
+
+    it('should initialize council if not exists', async () => {
+      const result = await router.route('Design something', 'creative');
+      expect(result.council).toBeDefined();
+      expect(result.council.id).toBeDefined();
+      expect(result.council.domain).toBe('creative');
+      expect(result.council.name).toBe('Creative');
+    });
+
+    it('should return active agents for council', async () => {
+      const result = await router.route('Design something', 'creative');
+      expect(result.agents).toBeDefined();
+      expect(Array.isArray(result.agents)).toBe(true);
+      expect(result.agents.length).toBeGreaterThan(0);
+      result.agents.forEach((agent: any) => {
+        expect(agent.isActive).toBe(true);
+      });
+    });
+
+    it('should initialize council with 4 agents', async () => {
+      const result = await router.route('Design something', 'creative');
+      expect(result.agents.length).toBe(4);
+    });
+  });
+
+  describe('getCouncils', () => {
+    it('should return empty array initially', () => {
+      const councils = router.getCouncils();
+      expect(Array.isArray(councils)).toBe(true);
+      expect(councils.length).toBe(0);
+    });
+
+    it('should return councils after routing', async () => {
+      await router.route('Design something', 'creative');
+      const councils = router.getCouncils();
+      expect(councils.length).toBeGreaterThan(0);
+    });
+  });
+});

--- a/src/council/router/council-router.ts
+++ b/src/council/router/council-router.ts
@@ -1,0 +1,133 @@
+import type { Council, Agent, DebateSession, CouncilDomain } from '../types';
+import { councilDb, agentDb, debateSessionDb } from '../storage/council-db';
+
+const DOMAIN_KEYWORDS: Record<CouncilDomain, string[]> = {
+  lifestyle: [
+    'food', 'restaurant', 'eat', 'drink', 'coffee', 'bar',
+    'fashion', 'clothes', 'wear', 'style', 'outfit',
+    'place', 'visit', 'travel', 'hotel', 'vacation',
+    'buy', 'purchase', 'shop', 'product', 'price',
+    'daily', 'routine', 'habit', 'activity'
+  ],
+  creative: [
+    'design', 'color', 'palette', 'font', 'typography',
+    'write', 'writing', 'copy', 'content', 'story',
+    'brand', 'branding', 'logo', 'visual', 'aesthetic',
+    'art', 'artistic', 'creative', 'style', 'layout',
+    'portfolio', 'project', 'presentation'
+  ],
+  direction: [
+    'career', 'job', 'work', 'profession', 'role',
+    'relationship', 'partner', 'friend', 'family',
+    'life', 'future', 'goal', 'path', 'decision',
+    'value', 'priority', 'important', 'meaning',
+    'change', 'move', 'opportunity', 'offer', 'accept'
+  ],
+};
+
+export interface RouteResult {
+  council: Council;
+  agents: Agent[];
+  session: DebateSession;
+}
+
+export interface ClassificationResult {
+  domain: CouncilDomain;
+  confidence: number;
+  reasoning: string;
+}
+
+export class CouncilRouter {
+  classifyDomain(prompt: string): ClassificationResult {
+    const lowerPrompt = prompt.toLowerCase();
+    const scores: Record<CouncilDomain, number> = {
+      lifestyle: 0,
+      creative: 0,
+      direction: 0,
+    };
+
+    for (const [domain, keywords] of Object.entries(DOMAIN_KEYWORDS)) {
+      for (const keyword of keywords) {
+        if (lowerPrompt.includes(keyword)) {
+          scores[domain as CouncilDomain]++;
+        }
+      }
+    }
+
+    let maxDomain: CouncilDomain = 'lifestyle';
+    let maxScore = 0;
+    let totalScore = 0;
+
+    for (const [domain, score] of Object.entries(scores)) {
+      totalScore += score;
+      if (score > maxScore) {
+        maxScore = score;
+        maxDomain = domain as CouncilDomain;
+      }
+    }
+
+    const confidence = totalScore > 0 ? maxScore / totalScore : 0.33;
+
+    return {
+      domain: maxDomain,
+      confidence,
+      reasoning: totalScore > 0
+        ? `Matched ${maxScore} keywords for ${maxDomain}`
+        : 'No keywords matched, defaulting to lifestyle',
+    };
+  }
+
+  async route(prompt: string, explicitCouncil?: CouncilDomain): Promise<RouteResult> {
+    const domain = explicitCouncil || this.classifyDomain(prompt).domain;
+
+    let council = councilDb.getByDomain(domain);
+    if (!council) {
+      council = await this.initializeCouncil(domain);
+    }
+
+    const agents = agentDb.getActiveByCouncil(council.id);
+
+    const session = debateSessionDb.insert({
+      councilId: council.id,
+      userPrompt: prompt,
+      phase: 'position',
+    });
+
+    return { council, agents, session };
+  }
+
+  private async initializeCouncil(domain: CouncilDomain): Promise<Council> {
+    const { councilConfig } = await import('../config/councils');
+    const councilDef = councilConfig.councils.find(c => c.domain === domain);
+
+    if (!councilDef) {
+      throw new Error(`No council definition found for domain: ${domain}`);
+    }
+
+    const council = councilDb.insert({
+      name: councilDef.name,
+      domain: councilDef.domain,
+      description: councilDef.description,
+    });
+
+    for (const agentDef of councilDef.agents) {
+      agentDb.insert({
+        councilId: council.id,
+        name: agentDef.name,
+        disposition: agentDef.disposition,
+        generation: 1,
+        memoryCapacity: agentDef.memoryCapacity || 100,
+        memoryUsed: 0,
+        isActive: true,
+      });
+    }
+
+    return council;
+  }
+
+  getCouncils(): Council[] {
+    return councilDb.getAll();
+  }
+}
+
+export const councilRouter = new CouncilRouter();

--- a/src/council/scoring/disposition-scorer.test.ts
+++ b/src/council/scoring/disposition-scorer.test.ts
@@ -1,0 +1,255 @@
+import { describe, it, expect } from 'bun:test';
+import type { AgentDisposition } from '../types';
+import {
+  scoreAgainstDisposition,
+  analyzeSentiment,
+  assessNovelty,
+  assessRisk,
+  assessPriorityAlignment,
+} from './disposition-scorer';
+
+describe('Disposition Scorer', () => {
+  // Sample dispositions for testing
+  const pragmatistDisposition: AgentDisposition = {
+    orientation: 'Pragmatist',
+    filterCriteria: {
+      keywords: ['cost', 'efficiency', 'practical', 'proven'],
+      sentimentBias: 'neutral',
+      noveltyPreference: 'low',
+      riskTolerance: 'low',
+    },
+    priorities: {
+      cost: 0.4,
+      quality: 0.3,
+      novelty: 0.1,
+      reliability: 0.2,
+    },
+    voice: {
+      tone: 'direct',
+      vocabulary: ['practical', 'efficient', 'proven'],
+    },
+  };
+
+  const explorerDisposition: AgentDisposition = {
+    orientation: 'Explorer',
+    filterCriteria: {
+      keywords: ['innovative', 'novel', 'experimental', 'cutting-edge'],
+      sentimentBias: 'positive',
+      noveltyPreference: 'high',
+      riskTolerance: 'high',
+    },
+    priorities: {
+      cost: 0.1,
+      quality: 0.2,
+      novelty: 0.5,
+      reliability: 0.2,
+    },
+    voice: {
+      tone: 'enthusiastic',
+      vocabulary: ['innovative', 'exciting', 'breakthrough'],
+    },
+  };
+
+  describe('scoreAgainstDisposition', () => {
+    it('should return a value between 0 and 1', () => {
+      const content = 'This is a test content';
+      const score = scoreAgainstDisposition(content, pragmatistDisposition);
+      expect(score).toBeGreaterThanOrEqual(0);
+      expect(score).toBeLessThanOrEqual(1);
+    });
+
+    it('should score higher when content matches disposition keywords', () => {
+      const pragmaticContent = 'This is a cost-effective and proven solution';
+      const score = scoreAgainstDisposition(pragmaticContent, pragmatistDisposition);
+      expect(score).toBeGreaterThan(0.1);
+    });
+
+    it('should score differently for different dispositions on same content', () => {
+      const content = 'This is an innovative and cutting-edge approach';
+      const pragmaticScore = scoreAgainstDisposition(content, pragmatistDisposition);
+      const explorerScore = scoreAgainstDisposition(content, explorerDisposition);
+      expect(pragmaticScore).not.toEqual(explorerScore);
+      expect(explorerScore).toBeGreaterThan(pragmaticScore);
+    });
+
+    it('should never exceed 1.0', () => {
+      const content =
+        'This is a cost-effective proven practical efficient solution with excellent quality and amazing innovation';
+      const score = scoreAgainstDisposition(content, pragmatistDisposition);
+      expect(score).toBeLessThanOrEqual(1);
+    });
+
+    it('should handle empty content', () => {
+      const score = scoreAgainstDisposition('', pragmatistDisposition);
+      expect(score).toBeGreaterThanOrEqual(0);
+      expect(score).toBeLessThanOrEqual(1);
+    });
+
+    it('should score pragmatist higher for cost-focused content', () => {
+      const costContent = 'We need to reduce costs and improve efficiency';
+      const score = scoreAgainstDisposition(costContent, pragmatistDisposition);
+      expect(score).toBeGreaterThan(0.15);
+    });
+
+    it('should score explorer higher for novelty-focused content', () => {
+      const noveltyContent = 'This is a revolutionary and innovative breakthrough';
+      const score = scoreAgainstDisposition(noveltyContent, explorerDisposition);
+      expect(score).toBeGreaterThan(0.15);
+    });
+  });
+
+  describe('analyzeSentiment', () => {
+    it('should detect positive sentiment', () => {
+      const sentiment = analyzeSentiment('This is great and amazing');
+      expect(sentiment).toBe('positive');
+    });
+
+    it('should detect negative sentiment', () => {
+      const sentiment = analyzeSentiment('This is terrible and awful');
+      expect(sentiment).toBe('negative');
+    });
+
+    it('should detect neutral sentiment', () => {
+      const sentiment = analyzeSentiment('This is a regular sentence');
+      expect(sentiment).toBe('neutral');
+    });
+
+    it('should handle mixed sentiment with more positive words', () => {
+      const sentiment = analyzeSentiment('Good and bad but excellent overall');
+      expect(sentiment).toBe('positive');
+    });
+
+    it('should handle mixed sentiment with more negative words', () => {
+      const sentiment = analyzeSentiment('Great but terrible and awful');
+      expect(sentiment).toBe('negative');
+    });
+  });
+
+  describe('assessNovelty', () => {
+    it('should return high novelty score for novel content', () => {
+      const score = assessNovelty('This is a new and innovative approach');
+      expect(score).toBeGreaterThan(0.5);
+    });
+
+    it('should return low novelty score for traditional content', () => {
+      const score = assessNovelty('This is a classic and proven method');
+      expect(score).toBeLessThan(0.5);
+    });
+
+    it('should return neutral score for balanced content', () => {
+      const score = assessNovelty('This is a new traditional approach');
+      expect(score).toBeCloseTo(0.5, 0.1);
+    });
+
+    it('should return 0.5 for content with no novelty indicators', () => {
+      const score = assessNovelty('This is a regular sentence');
+      expect(score).toBe(0.5);
+    });
+
+    it('should return value between 0 and 1', () => {
+      const score = assessNovelty('Any content here');
+      expect(score).toBeGreaterThanOrEqual(0);
+      expect(score).toBeLessThanOrEqual(1);
+    });
+  });
+
+  describe('assessRisk', () => {
+    it('should return high risk score for risky content', () => {
+      const score = assessRisk('This is a bold and experimental approach');
+      expect(score).toBeGreaterThan(0.5);
+    });
+
+    it('should return low risk score for safe content', () => {
+      const score = assessRisk('This is a safe and proven method');
+      expect(score).toBeLessThan(0.5);
+    });
+
+    it('should return neutral score for balanced content', () => {
+      const score = assessRisk('This is a risky safe approach');
+      expect(score).toBeCloseTo(0.5, 0.1);
+    });
+
+    it('should return 0.5 for content with no risk indicators', () => {
+      const score = assessRisk('This is a regular sentence');
+      expect(score).toBe(0.5);
+    });
+
+    it('should return value between 0 and 1', () => {
+      const score = assessRisk('Any content here');
+      expect(score).toBeGreaterThanOrEqual(0);
+      expect(score).toBeLessThanOrEqual(1);
+    });
+  });
+
+  describe('assessPriorityAlignment', () => {
+    it('should score high when content aligns with cost priority', () => {
+      const priorities = { cost: 0.5, quality: 0.2, novelty: 0.1, reliability: 0.2 };
+      const score = assessPriorityAlignment('We need to reduce costs and budget', priorities);
+      expect(score).toBeGreaterThan(0);
+    });
+
+    it('should score high when content aligns with quality priority', () => {
+      const priorities = { cost: 0.1, quality: 0.6, novelty: 0.1, reliability: 0.2 };
+      const score = assessPriorityAlignment('This is premium quality and excellent', priorities);
+      expect(score).toBeGreaterThan(0);
+    });
+
+    it('should score high when content aligns with novelty priority', () => {
+      const priorities = { cost: 0.1, quality: 0.2, novelty: 0.6, reliability: 0.1 };
+      const score = assessPriorityAlignment('This is new and innovative and latest', priorities);
+      expect(score).toBeGreaterThan(0);
+    });
+
+    it('should score high when content aligns with reliability priority', () => {
+      const priorities = { cost: 0.1, quality: 0.2, novelty: 0.1, reliability: 0.6 };
+      const score = assessPriorityAlignment('This is reliable and proven and trusted', priorities);
+      expect(score).toBeGreaterThan(0);
+    });
+
+    it('should return 0 when content does not align with any priority', () => {
+      const priorities = { cost: 0.1, quality: 0.1, novelty: 0.1, reliability: 0.1 };
+      const score = assessPriorityAlignment('Random unrelated content', priorities);
+      expect(score).toBe(0);
+    });
+
+    it('should return value between 0 and 1', () => {
+      const priorities = { cost: 0.25, quality: 0.25, novelty: 0.25, reliability: 0.25 };
+      const score = assessPriorityAlignment('Any content here', priorities);
+      expect(score).toBeGreaterThanOrEqual(0);
+      expect(score).toBeLessThanOrEqual(1);
+    });
+
+    it('should ignore priorities with low weights', () => {
+      const priorities = { cost: 0.05, quality: 0.05, novelty: 0.05, reliability: 0.05 };
+      const score = assessPriorityAlignment('This is very expensive and costly', priorities);
+      expect(score).toBe(0);
+    });
+  });
+
+  describe('Integration tests', () => {
+    it('should score pragmatist higher for practical, cost-focused content', () => {
+      const content =
+        'We should use proven technologies to reduce costs and improve efficiency';
+      const pragmaticScore = scoreAgainstDisposition(content, pragmatistDisposition);
+      const explorerScore = scoreAgainstDisposition(content, explorerDisposition);
+      expect(pragmaticScore).toBeGreaterThan(explorerScore);
+    });
+
+    it('should score explorer higher for innovative, novel content', () => {
+      const content =
+        'We should experiment with cutting-edge technologies and innovative approaches';
+      const pragmaticScore = scoreAgainstDisposition(content, pragmatistDisposition);
+      const explorerScore = scoreAgainstDisposition(content, explorerDisposition);
+      expect(explorerScore).toBeGreaterThan(pragmaticScore);
+    });
+
+    it('should handle complex content with mixed signals', () => {
+      const content =
+        'This innovative solution is cost-effective and proven, with excellent quality';
+      const pragmaticScore = scoreAgainstDisposition(content, pragmatistDisposition);
+      const explorerScore = scoreAgainstDisposition(content, explorerDisposition);
+      expect(pragmaticScore).toBeGreaterThan(0);
+      expect(explorerScore).toBeGreaterThan(0);
+    });
+  });
+});

--- a/src/council/scoring/disposition-scorer.ts
+++ b/src/council/scoring/disposition-scorer.ts
@@ -1,0 +1,203 @@
+import type { AgentDisposition } from '../types';
+
+/**
+ * Score content against an agent's disposition
+ * @param content - The content to evaluate
+ * @param disposition - The agent's disposition
+ * @returns Score between 0 and 1
+ */
+export function scoreAgainstDisposition(
+  content: string,
+  disposition: AgentDisposition
+): number {
+  let score = 0;
+
+  const keywordMatches = disposition.filterCriteria.keywords.filter((kw) =>
+    content.toLowerCase().includes(kw.toLowerCase())
+  ).length;
+  score += Math.min(0.3, keywordMatches * 0.1);
+
+  const sentiment = analyzeSentiment(content);
+  if (sentiment === disposition.filterCriteria.sentimentBias) {
+    score += 0.2;
+  } else if (disposition.filterCriteria.sentimentBias === 'neutral') {
+    score += 0.1;
+  }
+
+  const noveltyScore = assessNovelty(content);
+  if (disposition.filterCriteria.noveltyPreference === 'high' && noveltyScore > 0.5) {
+    score += 0.2;
+  } else if (
+    disposition.filterCriteria.noveltyPreference === 'low' &&
+    noveltyScore < 0.3
+  ) {
+    score += 0.2;
+  } else if (disposition.filterCriteria.noveltyPreference === 'balanced') {
+    score += 0.1;
+  }
+
+  const riskScore = assessRisk(content);
+  if (disposition.filterCriteria.riskTolerance === 'high' && riskScore > 0.5) {
+    score += 0.2;
+  } else if (
+    disposition.filterCriteria.riskTolerance === 'low' &&
+    riskScore < 0.3
+  ) {
+    score += 0.2;
+  } else if (disposition.filterCriteria.riskTolerance === 'moderate') {
+    score += 0.1;
+  }
+
+  score += assessPriorityAlignment(content, disposition.priorities) * 0.1;
+
+  return Math.min(1, Math.max(0, score));
+}
+
+export function analyzeSentiment(content: string): 'positive' | 'negative' | 'neutral' {
+  const positiveWords = [
+    'good',
+    'great',
+    'excellent',
+    'love',
+    'best',
+    'amazing',
+    'wonderful',
+    'beautiful',
+    'perfect',
+    'awesome',
+  ];
+  const negativeWords = [
+    'bad',
+    'terrible',
+    'awful',
+    'hate',
+    'worst',
+    'horrible',
+    'ugly',
+    'poor',
+    'disappointing',
+    'fail',
+  ];
+
+  const lowerContent = content.toLowerCase();
+  const positiveCount = positiveWords.filter((w) => lowerContent.includes(w)).length;
+  const negativeCount = negativeWords.filter((w) => lowerContent.includes(w)).length;
+
+  if (positiveCount > negativeCount) return 'positive';
+  if (negativeCount > positiveCount) return 'negative';
+  return 'neutral';
+}
+
+export function assessNovelty(content: string): number {
+  const noveltyWords = [
+    'new',
+    'innovative',
+    'unique',
+    'first',
+    'cutting-edge',
+    'revolutionary',
+    'fresh',
+    'novel',
+    'emerging',
+    'latest',
+  ];
+  const traditionalWords = [
+    'classic',
+    'traditional',
+    'proven',
+    'established',
+    'reliable',
+    'trusted',
+    'standard',
+    'conventional',
+  ];
+
+  const lowerContent = content.toLowerCase();
+  const noveltyCount = noveltyWords.filter((w) => lowerContent.includes(w)).length;
+  const traditionalCount = traditionalWords.filter((w) => lowerContent.includes(w)).length;
+
+  const total = noveltyCount + traditionalCount;
+  if (total === 0) return 0.5;
+  return noveltyCount / total;
+}
+
+export function assessRisk(content: string): number {
+  const riskWords = [
+    'risk',
+    'gamble',
+    'uncertain',
+    'volatile',
+    'experimental',
+    'speculative',
+    'bold',
+    'daring',
+  ];
+  const safeWords = [
+    'safe',
+    'secure',
+    'stable',
+    'guaranteed',
+    'proven',
+    'reliable',
+    'conservative',
+    'careful',
+  ];
+
+  const lowerContent = content.toLowerCase();
+  const riskCount = riskWords.filter((w) => lowerContent.includes(w)).length;
+  const safeCount = safeWords.filter((w) => lowerContent.includes(w)).length;
+
+  const total = riskCount + safeCount;
+  if (total === 0) return 0.5;
+  return riskCount / total;
+}
+
+export function assessPriorityAlignment(
+  content: string,
+  priorities: AgentDisposition['priorities']
+): number {
+  const lowerContent = content.toLowerCase();
+  let alignment = 0;
+
+  if (
+    priorities.cost > 0.3 &&
+    (lowerContent.includes('price') ||
+      lowerContent.includes('cost') ||
+      lowerContent.includes('value') ||
+      lowerContent.includes('budget'))
+  ) {
+    alignment += priorities.cost;
+  }
+
+  if (
+    priorities.quality > 0.3 &&
+    (lowerContent.includes('quality') ||
+      lowerContent.includes('premium') ||
+      lowerContent.includes('best') ||
+      lowerContent.includes('excellent'))
+  ) {
+    alignment += priorities.quality;
+  }
+
+  if (
+    priorities.novelty > 0.3 &&
+    (lowerContent.includes('new') ||
+      lowerContent.includes('innovative') ||
+      lowerContent.includes('trend') ||
+      lowerContent.includes('latest'))
+  ) {
+    alignment += priorities.novelty;
+  }
+
+  if (
+    priorities.reliability > 0.3 &&
+    (lowerContent.includes('reliable') ||
+      lowerContent.includes('consistent') ||
+      lowerContent.includes('proven') ||
+      lowerContent.includes('trusted'))
+  ) {
+    alignment += priorities.reliability;
+  }
+
+  return Math.min(1, alignment);
+}

--- a/src/council/storage/council-db.test.ts
+++ b/src/council/storage/council-db.test.ts
@@ -1,0 +1,969 @@
+import { describe, it, expect, beforeAll, afterAll } from 'bun:test';
+import { Database } from 'bun:sqlite';
+import { initCouncilDb } from '../db';
+import {
+  councilDb,
+  agentDb,
+  memoryDb,
+  generationDb,
+  debateSessionDb,
+  debateTurnDb,
+  adoptionDb,
+  setDb,
+} from './council-db';
+import type {
+  Council,
+  Agent,
+  Memory,
+  Generation,
+  DebateSession,
+  DebateTurn,
+  AdoptionRecord,
+  AgentDisposition,
+} from '../types';
+import { join } from 'path';
+import { homedir } from 'os';
+import { existsSync, unlinkSync } from 'fs';
+
+const TEST_DB_PATH = join(homedir(), '.clawdbot', 'test-council-crud.db');
+
+describe('Council CRUD Storage Layer', () => {
+  let db: Database;
+
+  beforeAll(() => {
+    if (existsSync(TEST_DB_PATH)) {
+      unlinkSync(TEST_DB_PATH);
+    }
+    db = initCouncilDb(TEST_DB_PATH);
+    setDb(db);
+  });
+
+  afterAll(() => {
+    db.close();
+    if (existsSync(TEST_DB_PATH)) {
+      unlinkSync(TEST_DB_PATH);
+    }
+  });
+
+  const cleanupCouncils = () => {
+    db.exec('DELETE FROM adoption_history');
+    db.exec('DELETE FROM debate_turns');
+    db.exec('DELETE FROM debate_sessions');
+    db.exec('DELETE FROM generations');
+    db.exec('DELETE FROM memories');
+    db.exec('DELETE FROM agents');
+    db.exec('DELETE FROM councils');
+  };
+
+  // ============================================================================
+  // Council CRUD Tests
+  // ============================================================================
+
+  describe('Council CRUD', () => {
+    it('should insert a council and return it with generated ID', () => {
+      cleanupCouncils();
+      const council = councilDb.insert({
+        name: 'Lifestyle Council',
+        domain: 'lifestyle',
+        description: 'Discusses lifestyle decisions',
+      });
+
+      expect(council.id).toBeDefined();
+      expect(council.id.startsWith('council_')).toBe(true);
+      expect(council.name).toBe('Lifestyle Council');
+      expect(council.domain).toBe('lifestyle');
+      expect(council.createdAt).toBeDefined();
+      expect(typeof council.createdAt).toBe('number');
+    });
+
+    it('should get council by ID', () => {
+      cleanupCouncils();
+      const inserted = councilDb.insert({
+        name: 'Creative Council',
+        domain: 'creative',
+        description: 'Discusses creative projects',
+      });
+
+      const retrieved = councilDb.getById(inserted.id);
+      expect(retrieved).not.toBeNull();
+      expect(retrieved?.id).toBe(inserted.id);
+      expect(retrieved?.name).toBe('Creative Council');
+    });
+
+    it('should return null for non-existent council ID', () => {
+      const result = councilDb.getById('non-existent-id');
+      expect(result).toBeNull();
+    });
+
+    it('should get council by domain', () => {
+      cleanupCouncils();
+      const inserted = councilDb.insert({
+        name: 'Direction Council',
+        domain: 'direction',
+        description: 'Discusses direction',
+      });
+
+      const retrieved = councilDb.getByDomain('direction');
+      expect(retrieved).not.toBeNull();
+      expect(retrieved?.domain).toBe('direction');
+      expect(retrieved?.id).toBe(inserted.id);
+    });
+
+    it('should get all councils', () => {
+      cleanupCouncils();
+      councilDb.insert({
+        name: 'Council 1',
+        domain: 'lifestyle',
+      });
+      councilDb.insert({
+        name: 'Council 2',
+        domain: 'creative',
+      });
+      councilDb.insert({
+        name: 'Council 3',
+        domain: 'direction',
+      });
+
+      const all = councilDb.getAll();
+      expect(all.length).toBe(3);
+    });
+
+    it('should update a council', () => {
+      cleanupCouncils();
+      const inserted = councilDb.insert({
+        name: 'Original Name',
+        domain: 'lifestyle',
+      });
+
+      const updated = councilDb.update(inserted.id, {
+        name: 'Updated Name',
+        description: 'New description',
+      });
+
+      expect(updated).toBe(true);
+
+      const retrieved = councilDb.getById(inserted.id);
+      expect(retrieved?.name).toBe('Updated Name');
+      expect(retrieved?.description).toBe('New description');
+    });
+
+    it('should return false when updating non-existent council', () => {
+      const result = councilDb.update('non-existent-id', { name: 'Test' });
+      expect(result).toBe(false);
+    });
+
+    it('should delete a council', () => {
+      cleanupCouncils();
+      const inserted = councilDb.insert({
+        name: 'To Delete',
+        domain: 'lifestyle',
+      });
+
+      const deleted = councilDb.delete(inserted.id);
+      expect(deleted).toBe(true);
+
+      const retrieved = councilDb.getById(inserted.id);
+      expect(retrieved).toBeNull();
+    });
+
+    it('should return false when deleting non-existent council', () => {
+      const result = councilDb.delete('non-existent-id');
+      expect(result).toBe(false);
+    });
+  });
+
+  // ============================================================================
+  // Agent CRUD Tests
+  // ============================================================================
+
+  describe('Agent CRUD', () => {
+    let councilId: string;
+
+    beforeAll(() => {
+      cleanupCouncils();
+      const council = councilDb.insert({
+        name: 'Test Council for Agents',
+        domain: 'lifestyle',
+      });
+      councilId = council.id;
+    });
+
+    const createTestDisposition = (): AgentDisposition => ({
+      orientation: 'pragmatic',
+      filterCriteria: {
+        keywords: ['practical', 'efficient'],
+        sentimentBias: 'neutral',
+        noveltyPreference: 'balanced',
+        riskTolerance: 'moderate',
+      },
+      priorities: {
+        cost: 0.3,
+        quality: 0.3,
+        novelty: 0.2,
+        reliability: 0.2,
+      },
+      voice: {
+        tone: 'professional',
+        vocabulary: ['efficient', 'practical'],
+      },
+    });
+
+    it('should insert an agent and return it with generated ID', () => {
+      const agent = agentDb.insert({
+        councilId,
+        name: 'Pragmatist',
+        disposition: createTestDisposition(),
+        generation: 1,
+        memoryCapacity: 100,
+        memoryUsed: 0,
+        isActive: true,
+      });
+
+      expect(agent.id).toBeDefined();
+      expect(agent.id.startsWith('agent_')).toBe(true);
+      expect(agent.name).toBe('Pragmatist');
+      expect(agent.councilId).toBe(councilId);
+      expect(agent.generation).toBe(1);
+      expect(agent.createdAt).toBeDefined();
+    });
+
+    it('should get agent by ID', () => {
+      const inserted = agentDb.insert({
+        councilId,
+        name: 'Idealist',
+        disposition: createTestDisposition(),
+        generation: 1,
+        memoryCapacity: 100,
+        memoryUsed: 0,
+        isActive: true,
+      });
+
+      const retrieved = agentDb.getById(inserted.id);
+      expect(retrieved).not.toBeNull();
+      expect(retrieved?.id).toBe(inserted.id);
+      expect(retrieved?.name).toBe('Idealist');
+    });
+
+    it('should get agents by council', () => {
+      agentDb.insert({
+        councilId,
+        name: 'Agent 1',
+        disposition: createTestDisposition(),
+        generation: 1,
+        memoryCapacity: 100,
+        memoryUsed: 0,
+        isActive: true,
+      });
+
+      agentDb.insert({
+        councilId,
+        name: 'Agent 2',
+        disposition: createTestDisposition(),
+        generation: 1,
+        memoryCapacity: 100,
+        memoryUsed: 0,
+        isActive: true,
+      });
+
+      const agents = agentDb.getByCouncil(councilId);
+      expect(agents.length).toBeGreaterThanOrEqual(2);
+      expect(agents.every((a) => a.councilId === councilId)).toBe(true);
+    });
+
+    it('should get only active agents by council', () => {
+      const active = agentDb.insert({
+        councilId,
+        name: 'Active Agent',
+        disposition: createTestDisposition(),
+        generation: 1,
+        memoryCapacity: 100,
+        memoryUsed: 0,
+        isActive: true,
+      });
+
+      const inactive = agentDb.insert({
+        councilId,
+        name: 'Inactive Agent',
+        disposition: createTestDisposition(),
+        generation: 1,
+        memoryCapacity: 100,
+        memoryUsed: 0,
+        isActive: false,
+      });
+
+      const activeAgents = agentDb.getActiveByCouncil(councilId);
+      expect(activeAgents.every((a) => a.isActive)).toBe(true);
+      expect(activeAgents.some((a) => a.id === active.id)).toBe(true);
+      expect(activeAgents.some((a) => a.id === inactive.id)).toBe(false);
+    });
+
+    it('should update an agent', () => {
+      const inserted = agentDb.insert({
+        councilId,
+        name: 'Original Name',
+        disposition: createTestDisposition(),
+        generation: 1,
+        memoryCapacity: 100,
+        memoryUsed: 0,
+        isActive: true,
+      });
+
+      const updated = agentDb.update(inserted.id, {
+        name: 'Updated Name',
+        generation: 2,
+        isActive: false,
+      });
+
+      expect(updated).toBe(true);
+
+      const retrieved = agentDb.getById(inserted.id);
+      expect(retrieved?.name).toBe('Updated Name');
+      expect(retrieved?.generation).toBe(2);
+      expect(retrieved?.isActive).toBe(false);
+    });
+
+    it('should delete an agent', () => {
+      const inserted = agentDb.insert({
+        councilId,
+        name: 'To Delete',
+        disposition: createTestDisposition(),
+        generation: 1,
+        memoryCapacity: 100,
+        memoryUsed: 0,
+        isActive: true,
+      });
+
+      const deleted = agentDb.delete(inserted.id);
+      expect(deleted).toBe(true);
+
+      const retrieved = agentDb.getById(inserted.id);
+      expect(retrieved).toBeNull();
+    });
+  });
+
+  // ============================================================================
+  // Memory CRUD Tests
+  // ============================================================================
+
+  describe('Memory CRUD', () => {
+    let agentId: string;
+
+    beforeAll(() => {
+      cleanupCouncils();
+      const council = councilDb.insert({
+        name: 'Test Council for Memories',
+        domain: 'lifestyle',
+      });
+
+      const agent = agentDb.insert({
+        councilId: council.id,
+        name: 'Test Agent',
+        disposition: {
+          orientation: 'pragmatic',
+          filterCriteria: {
+            keywords: ['test'],
+            sentimentBias: 'neutral',
+            noveltyPreference: 'balanced',
+            riskTolerance: 'moderate',
+          },
+          priorities: { cost: 0.25, quality: 0.25, novelty: 0.25, reliability: 0.25 },
+          voice: { tone: 'neutral', vocabulary: ['test'] },
+        },
+        generation: 1,
+        memoryCapacity: 100,
+        memoryUsed: 0,
+        isActive: true,
+      });
+
+      agentId = agent.id;
+    });
+
+    it('should insert a memory and return it with generated ID', () => {
+      const memory = memoryDb.insert({
+        agentId,
+        content: 'Test memory content',
+        dispositionScore: 0.8,
+        sourceType: 'debate',
+        sourceRef: 'session-123',
+      });
+
+      expect(memory.id).toBeDefined();
+      expect(memory.id.startsWith('memory_')).toBe(true);
+      expect(memory.content).toBe('Test memory content');
+      expect(memory.dispositionScore).toBe(0.8);
+      expect(memory.createdAt).toBeDefined();
+    });
+
+    it('should get memory by ID', () => {
+      const inserted = memoryDb.insert({
+        agentId,
+        content: 'Specific memory',
+        dispositionScore: 0.7,
+        sourceType: 'observation',
+      });
+
+      const retrieved = memoryDb.getById(inserted.id);
+      expect(retrieved).not.toBeNull();
+      expect(retrieved?.id).toBe(inserted.id);
+      expect(retrieved?.content).toBe('Specific memory');
+    });
+
+    it('should get memories by agent', () => {
+      memoryDb.insert({
+        agentId,
+        content: 'Memory 1',
+        dispositionScore: 0.6,
+        sourceType: 'debate',
+      });
+
+      memoryDb.insert({
+        agentId,
+        content: 'Memory 2',
+        dispositionScore: 0.7,
+        sourceType: 'observation',
+      });
+
+      const memories = memoryDb.getByAgent(agentId);
+      expect(memories.length).toBeGreaterThanOrEqual(2);
+      expect(memories.every((m) => m.agentId === agentId)).toBe(true);
+    });
+
+    it('should get lowest scoring memory for displacement', () => {
+      memoryDb.insert({
+        agentId,
+        content: 'High score',
+        dispositionScore: 0.9,
+        sourceType: 'debate',
+      });
+
+      memoryDb.insert({
+        agentId,
+        content: 'Low score',
+        dispositionScore: 0.2,
+        sourceType: 'observation',
+      });
+
+      const lowest = memoryDb.getLowestScoring(agentId);
+      expect(lowest).not.toBeNull();
+      expect(lowest?.dispositionScore).toBeLessThanOrEqual(0.3);
+    });
+
+    it('should get top memories by score', () => {
+      memoryDb.insert({
+        agentId,
+        content: 'Top 1',
+        dispositionScore: 0.95,
+        sourceType: 'debate',
+      });
+
+      memoryDb.insert({
+        agentId,
+        content: 'Top 2',
+        dispositionScore: 0.92,
+        sourceType: 'debate',
+      });
+
+      memoryDb.insert({
+        agentId,
+        content: 'Low',
+        dispositionScore: 0.3,
+        sourceType: 'observation',
+      });
+
+      const top = memoryDb.getTopByScore(agentId, 2);
+      expect(top.length).toBeLessThanOrEqual(2);
+      expect(top[0].dispositionScore).toBeGreaterThanOrEqual(top[1]?.dispositionScore || 0);
+    });
+
+    it('should update a memory', () => {
+      const inserted = memoryDb.insert({
+        agentId,
+        content: 'Original content',
+        dispositionScore: 0.5,
+        sourceType: 'debate',
+      });
+
+      const updated = memoryDb.update(inserted.id, {
+        content: 'Updated content',
+        dispositionScore: 0.8,
+      });
+
+      expect(updated).toBe(true);
+
+      const retrieved = memoryDb.getById(inserted.id);
+      expect(retrieved?.content).toBe('Updated content');
+      expect(retrieved?.dispositionScore).toBe(0.8);
+    });
+
+    it('should delete a memory', () => {
+      const inserted = memoryDb.insert({
+        agentId,
+        content: 'To delete',
+        dispositionScore: 0.5,
+        sourceType: 'debate',
+      });
+
+      const deleted = memoryDb.delete(inserted.id);
+      expect(deleted).toBe(true);
+
+      const retrieved = memoryDb.getById(inserted.id);
+      expect(retrieved).toBeNull();
+    });
+
+    it('should count memories by agent', () => {
+      const before = memoryDb.countByAgent(agentId);
+      memoryDb.insert({
+        agentId,
+        content: 'New memory',
+        dispositionScore: 0.5,
+        sourceType: 'debate',
+      });
+      const after = memoryDb.countByAgent(agentId);
+      expect(after).toBeGreaterThan(before);
+    });
+  });
+
+  // ============================================================================
+  // Generation CRUD Tests
+  // ============================================================================
+
+  describe('Generation CRUD', () => {
+    let agentId: string;
+
+    beforeAll(() => {
+      cleanupCouncils();
+      const council = councilDb.insert({
+        name: 'Test Council for Generations',
+        domain: 'lifestyle',
+      });
+
+      const agent = agentDb.insert({
+        councilId: council.id,
+        name: 'Test Agent',
+        disposition: {
+          orientation: 'pragmatic',
+          filterCriteria: {
+            keywords: ['test'],
+            sentimentBias: 'neutral',
+            noveltyPreference: 'balanced',
+            riskTolerance: 'moderate',
+          },
+          priorities: { cost: 0.25, quality: 0.25, novelty: 0.25, reliability: 0.25 },
+          voice: { tone: 'neutral', vocabulary: ['test'] },
+        },
+        generation: 1,
+        memoryCapacity: 100,
+        memoryUsed: 0,
+        isActive: true,
+      });
+
+      agentId = agent.id;
+    });
+
+    it('should insert a generation and return it with generated ID', () => {
+      const disposition = {
+        orientation: 'pragmatic',
+        filterCriteria: {
+          keywords: ['test'],
+          sentimentBias: 'neutral' as const,
+          noveltyPreference: 'balanced' as const,
+          riskTolerance: 'moderate' as const,
+        },
+        priorities: { cost: 0.25, quality: 0.25, novelty: 0.25, reliability: 0.25 },
+        voice: { tone: 'neutral', vocabulary: ['test'] },
+      };
+
+      const generation = generationDb.insert({
+        agentId,
+        generationNum: 1,
+        dispositionSnapshot: disposition,
+        seedMemories: ['mem-1', 'mem-2'],
+      });
+
+      expect(generation.id).toBeDefined();
+      expect(generation.id.startsWith('gen_')).toBe(true);
+      expect(generation.generationNum).toBe(1);
+      expect(generation.createdAt).toBeDefined();
+    });
+
+    it('should get generation by ID', () => {
+      const disposition = {
+        orientation: 'pragmatic',
+        filterCriteria: {
+          keywords: ['test'],
+          sentimentBias: 'neutral' as const,
+          noveltyPreference: 'balanced' as const,
+          riskTolerance: 'moderate' as const,
+        },
+        priorities: { cost: 0.25, quality: 0.25, novelty: 0.25, reliability: 0.25 },
+        voice: { tone: 'neutral', vocabulary: ['test'] },
+      };
+
+      const inserted = generationDb.insert({
+        agentId,
+        generationNum: 2,
+        dispositionSnapshot: disposition,
+      });
+
+      const retrieved = generationDb.getById(inserted.id);
+      expect(retrieved).not.toBeNull();
+      expect(retrieved?.id).toBe(inserted.id);
+      expect(retrieved?.generationNum).toBe(2);
+    });
+
+    it('should get generations by agent', () => {
+      const disposition = {
+        orientation: 'pragmatic',
+        filterCriteria: {
+          keywords: ['test'],
+          sentimentBias: 'neutral' as const,
+          noveltyPreference: 'balanced' as const,
+          riskTolerance: 'moderate' as const,
+        },
+        priorities: { cost: 0.25, quality: 0.25, novelty: 0.25, reliability: 0.25 },
+        voice: { tone: 'neutral', vocabulary: ['test'] },
+      };
+
+      generationDb.insert({
+        agentId,
+        generationNum: 3,
+        dispositionSnapshot: disposition,
+      });
+
+      const generations = generationDb.getByAgent(agentId);
+      expect(generations.length).toBeGreaterThanOrEqual(1);
+      expect(generations.every((g) => g.agentId === agentId)).toBe(true);
+    });
+
+    it('should get latest generation for agent', () => {
+      const disposition = {
+        orientation: 'pragmatic',
+        filterCriteria: {
+          keywords: ['test'],
+          sentimentBias: 'neutral' as const,
+          noveltyPreference: 'balanced' as const,
+          riskTolerance: 'moderate' as const,
+        },
+        priorities: { cost: 0.25, quality: 0.25, novelty: 0.25, reliability: 0.25 },
+        voice: { tone: 'neutral', vocabulary: ['test'] },
+      };
+
+      generationDb.insert({
+        agentId,
+        generationNum: 4,
+        dispositionSnapshot: disposition,
+      });
+
+      const latest = generationDb.getLatest(agentId);
+      expect(latest).not.toBeNull();
+      expect(latest?.agentId).toBe(agentId);
+    });
+
+    it('should update a generation', () => {
+      const disposition = {
+        orientation: 'pragmatic',
+        filterCriteria: {
+          keywords: ['test'],
+          sentimentBias: 'neutral' as const,
+          noveltyPreference: 'balanced' as const,
+          riskTolerance: 'moderate' as const,
+        },
+        priorities: { cost: 0.25, quality: 0.25, novelty: 0.25, reliability: 0.25 },
+        voice: { tone: 'neutral', vocabulary: ['test'] },
+      };
+
+      const inserted = generationDb.insert({
+        agentId,
+        generationNum: 5,
+        dispositionSnapshot: disposition,
+      });
+
+      const updated = generationDb.update(inserted.id, {
+        retiredAt: Date.now(),
+      });
+
+      expect(updated).toBe(true);
+
+      const retrieved = generationDb.getById(inserted.id);
+      expect(retrieved?.retiredAt).toBeDefined();
+    });
+  });
+
+  // ============================================================================
+  // DebateSession CRUD Tests
+  // ============================================================================
+
+  describe('DebateSession CRUD', () => {
+    let councilId: string;
+
+    beforeAll(() => {
+      cleanupCouncils();
+      const council = councilDb.insert({
+        name: 'Test Council for Sessions',
+        domain: 'lifestyle',
+      });
+      councilId = council.id;
+    });
+
+    it('should insert a debate session and return it with generated ID', () => {
+      const session = debateSessionDb.insert({
+        councilId,
+        userPrompt: 'Should I change careers?',
+        phase: 'position',
+      });
+
+      expect(session.id).toBeDefined();
+      expect(session.id.startsWith('session_')).toBe(true);
+      expect(session.userPrompt).toBe('Should I change careers?');
+      expect(session.phase).toBe('position');
+      expect(session.createdAt).toBeDefined();
+    });
+
+    it('should get debate session by ID', () => {
+      const inserted = debateSessionDb.insert({
+        councilId,
+        userPrompt: 'Test prompt',
+        phase: 'challenge',
+      });
+
+      const retrieved = debateSessionDb.getById(inserted.id);
+      expect(retrieved).not.toBeNull();
+      expect(retrieved?.id).toBe(inserted.id);
+      expect(retrieved?.userPrompt).toBe('Test prompt');
+    });
+
+    it('should get debate sessions by council', () => {
+      debateSessionDb.insert({
+        councilId,
+        userPrompt: 'Session 1',
+        phase: 'position',
+      });
+
+      debateSessionDb.insert({
+        councilId,
+        userPrompt: 'Session 2',
+        phase: 'challenge',
+      });
+
+      const sessions = debateSessionDb.getByCouncil(councilId);
+      expect(sessions.length).toBeGreaterThanOrEqual(2);
+      expect(sessions.every((s) => s.councilId === councilId)).toBe(true);
+    });
+
+    it('should update a debate session', () => {
+      const inserted = debateSessionDb.insert({
+        councilId,
+        userPrompt: 'Original prompt',
+        phase: 'position',
+      });
+
+      const updated = debateSessionDb.update(inserted.id, {
+        phase: 'synthesis',
+        synthesis: 'The synthesis is...',
+        completedAt: Date.now(),
+      });
+
+      expect(updated).toBe(true);
+
+      const retrieved = debateSessionDb.getById(inserted.id);
+      expect(retrieved?.phase).toBe('synthesis');
+      expect(retrieved?.synthesis).toBe('The synthesis is...');
+      expect(retrieved?.completedAt).toBeDefined();
+    });
+  });
+
+  // ============================================================================
+  // DebateTurn CRUD Tests
+  // ============================================================================
+
+  describe('DebateTurn CRUD', () => {
+    let sessionId: string;
+    let agentId: string;
+
+    beforeAll(() => {
+      cleanupCouncils();
+      const council = councilDb.insert({
+        name: 'Test Council for Turns',
+        domain: 'lifestyle',
+      });
+
+      const agent = agentDb.insert({
+        councilId: council.id,
+        name: 'Test Agent',
+        disposition: {
+          orientation: 'pragmatic',
+          filterCriteria: {
+            keywords: ['test'],
+            sentimentBias: 'neutral',
+            noveltyPreference: 'balanced',
+            riskTolerance: 'moderate',
+          },
+          priorities: { cost: 0.25, quality: 0.25, novelty: 0.25, reliability: 0.25 },
+          voice: { tone: 'neutral', vocabulary: ['test'] },
+        },
+        generation: 1,
+        memoryCapacity: 100,
+        memoryUsed: 0,
+        isActive: true,
+      });
+
+      const session = debateSessionDb.insert({
+        councilId: council.id,
+        userPrompt: 'Test debate',
+        phase: 'position',
+      });
+
+      sessionId = session.id;
+      agentId = agent.id;
+    });
+
+    it('should insert a debate turn and return it with generated ID', () => {
+      const turn = debateTurnDb.insert({
+        sessionId,
+        agentId,
+        phase: 'position',
+        content: 'I believe we should...',
+      });
+
+      expect(turn.id).toBeDefined();
+      expect(turn.id.startsWith('turn_')).toBe(true);
+      expect(turn.content).toBe('I believe we should...');
+      expect(turn.phase).toBe('position');
+      expect(turn.createdAt).toBeDefined();
+    });
+
+    it('should get debate turns by session', () => {
+      debateTurnDb.insert({
+        sessionId,
+        agentId,
+        phase: 'position',
+        content: 'Turn 1',
+      });
+
+      debateTurnDb.insert({
+        sessionId,
+        agentId,
+        phase: 'challenge',
+        content: 'Turn 2',
+      });
+
+      const turns = debateTurnDb.getBySession(sessionId);
+      expect(turns.length).toBeGreaterThanOrEqual(2);
+      expect(turns.every((t) => t.sessionId === sessionId)).toBe(true);
+    });
+
+    it('should get debate turns by session and phase', () => {
+      debateTurnDb.insert({
+        sessionId,
+        agentId,
+        phase: 'position',
+        content: 'Position turn',
+      });
+
+      debateTurnDb.insert({
+        sessionId,
+        agentId,
+        phase: 'challenge',
+        content: 'Challenge turn',
+      });
+
+      const positionTurns = debateTurnDb.getBySessionAndPhase(sessionId, 'position');
+      expect(positionTurns.every((t) => t.phase === 'position')).toBe(true);
+
+      const challengeTurns = debateTurnDb.getBySessionAndPhase(sessionId, 'challenge');
+      expect(challengeTurns.every((t) => t.phase === 'challenge')).toBe(true);
+    });
+  });
+
+  // ============================================================================
+  // AdoptionRecord CRUD Tests
+  // ============================================================================
+
+  describe('AdoptionRecord CRUD', () => {
+    let agentId: string;
+    let sessionId: string;
+
+    beforeAll(() => {
+      cleanupCouncils();
+      const council = councilDb.insert({
+        name: 'Test Council for Adoption',
+        domain: 'lifestyle',
+      });
+
+      const agent = agentDb.insert({
+        councilId: council.id,
+        name: 'Test Agent',
+        disposition: {
+          orientation: 'pragmatic',
+          filterCriteria: {
+            keywords: ['test'],
+            sentimentBias: 'neutral',
+            noveltyPreference: 'balanced',
+            riskTolerance: 'moderate',
+          },
+          priorities: { cost: 0.25, quality: 0.25, novelty: 0.25, reliability: 0.25 },
+          voice: { tone: 'neutral', vocabulary: ['test'] },
+        },
+        generation: 1,
+        memoryCapacity: 100,
+        memoryUsed: 0,
+        isActive: true,
+      });
+
+      const session = debateSessionDb.insert({
+        councilId: council.id,
+        userPrompt: 'Test debate',
+        phase: 'complete',
+      });
+
+      agentId = agent.id;
+      sessionId = session.id;
+    });
+
+    it('should insert an adoption record and return it with generated ID', () => {
+      const record = adoptionDb.insert({
+        agentId,
+        sessionId,
+        decision: 'adopted',
+        userFeedback: 'Great suggestion!',
+      });
+
+      expect(record.id).toBeDefined();
+      expect(record.id.startsWith('adoption_')).toBe(true);
+      expect(record.decision).toBe('adopted');
+      expect(record.createdAt).toBeDefined();
+    });
+
+    it('should get adoption records by agent', () => {
+      adoptionDb.insert({
+        agentId,
+        sessionId,
+        decision: 'rejected',
+        userFeedback: 'Not applicable',
+      });
+
+      adoptionDb.insert({
+        agentId,
+        sessionId,
+        decision: 'partial',
+        userFeedback: 'Partially useful',
+      });
+
+      const records = adoptionDb.getByAgent(agentId);
+      expect(records.length).toBeGreaterThanOrEqual(2);
+      expect(records.every((r) => r.agentId === agentId)).toBe(true);
+    });
+
+    it('should get adoption records by session', () => {
+      adoptionDb.insert({
+        agentId,
+        sessionId,
+        decision: 'adopted',
+      });
+
+      const records = adoptionDb.getBySession(sessionId);
+      expect(records.length).toBeGreaterThanOrEqual(1);
+      expect(records.every((r) => r.sessionId === sessionId)).toBe(true);
+    });
+  });
+});

--- a/src/council/storage/council-db.ts
+++ b/src/council/storage/council-db.ts
@@ -1,0 +1,762 @@
+import { Database } from 'bun:sqlite';
+import { initCouncilDb } from '../db';
+import type {
+  Council,
+  Agent,
+  Memory,
+  Generation,
+  DebateSession,
+  DebateTurn,
+  AdoptionRecord,
+  AgentDisposition,
+  CouncilDomain,
+} from '../types';
+
+let db: Database | null = null;
+
+function getDb(): Database {
+  if (!db) {
+    db = initCouncilDb();
+  }
+  return db;
+}
+
+export function setDb(database: Database): void {
+  db = database;
+}
+
+function generateId(prefix: string): string {
+  return `${prefix}_${Date.now()}_${Math.random().toString(36).substr(2, 9)}`;
+}
+
+export const councilDb = {
+  insert(council: Omit<Council, 'id' | 'createdAt'>): Council {
+    const db = getDb();
+    const id = generateId('council');
+    const createdAt = Date.now();
+
+    const stmt = db.prepare(
+      'INSERT INTO councils (id, name, domain, description, created_at) VALUES (?, ?, ?, ?, ?)'
+    );
+    stmt.run(id, council.name, council.domain, council.description || null, createdAt);
+
+    return {
+      id,
+      name: council.name,
+      domain: council.domain,
+      description: council.description,
+      createdAt,
+    };
+  },
+
+  getById(id: string): Council | null {
+    const db = getDb();
+    const stmt = db.prepare('SELECT * FROM councils WHERE id = ?');
+    const row = stmt.get(id) as any;
+
+    if (!row) return null;
+
+    return {
+      id: row.id,
+      name: row.name,
+      domain: row.domain as CouncilDomain,
+      description: row.description,
+      createdAt: row.created_at,
+    };
+  },
+
+  getByDomain(domain: CouncilDomain): Council | null {
+    const db = getDb();
+    const stmt = db.prepare('SELECT * FROM councils WHERE domain = ?');
+    const row = stmt.get(domain) as any;
+
+    if (!row) return null;
+
+    return {
+      id: row.id,
+      name: row.name,
+      domain: row.domain as CouncilDomain,
+      description: row.description,
+      createdAt: row.created_at,
+    };
+  },
+
+  getAll(): Council[] {
+    const db = getDb();
+    const stmt = db.prepare('SELECT * FROM councils ORDER BY created_at DESC');
+    const rows = stmt.all() as any[];
+
+    return rows.map((row) => ({
+      id: row.id,
+      name: row.name,
+      domain: row.domain as CouncilDomain,
+      description: row.description,
+      createdAt: row.created_at,
+    }));
+  },
+
+  update(id: string, updates: Partial<Council>): boolean {
+    const db = getDb();
+    const fields: string[] = [];
+    const values: any[] = [];
+
+    if (updates.name !== undefined) {
+      fields.push('name = ?');
+      values.push(updates.name);
+    }
+    if (updates.description !== undefined) {
+      fields.push('description = ?');
+      values.push(updates.description);
+    }
+
+    if (fields.length === 0) return false;
+
+    values.push(id);
+    const stmt = db.prepare(`UPDATE councils SET ${fields.join(', ')} WHERE id = ?`);
+    const result = stmt.run(...values);
+
+    return result.changes > 0;
+  },
+
+  delete(id: string): boolean {
+    const db = getDb();
+    const stmt = db.prepare('DELETE FROM councils WHERE id = ?');
+    const result = stmt.run(id);
+    return result.changes > 0;
+  },
+};
+
+export const agentDb = {
+  insert(agent: Omit<Agent, 'id' | 'createdAt'>): Agent {
+    const db = getDb();
+    const id = generateId('agent');
+    const createdAt = Date.now();
+
+    const stmt = db.prepare(
+      'INSERT INTO agents (id, council_id, name, disposition, generation, memory_capacity, memory_used, predecessor_id, is_active, created_at) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)'
+    );
+    stmt.run(
+      id,
+      agent.councilId,
+      agent.name,
+      JSON.stringify(agent.disposition),
+      agent.generation,
+      agent.memoryCapacity,
+      agent.memoryUsed,
+      agent.predecessorId || null,
+      agent.isActive ? 1 : 0,
+      createdAt
+    );
+
+    return {
+      id,
+      councilId: agent.councilId,
+      name: agent.name,
+      disposition: agent.disposition,
+      generation: agent.generation,
+      memoryCapacity: agent.memoryCapacity,
+      memoryUsed: agent.memoryUsed,
+      predecessorId: agent.predecessorId,
+      isActive: agent.isActive,
+      createdAt,
+    };
+  },
+
+  getById(id: string): Agent | null {
+    const db = getDb();
+    const stmt = db.prepare('SELECT * FROM agents WHERE id = ?');
+    const row = stmt.get(id) as any;
+
+    if (!row) return null;
+
+    return {
+      id: row.id,
+      councilId: row.council_id,
+      name: row.name,
+      disposition: JSON.parse(row.disposition),
+      generation: row.generation,
+      memoryCapacity: row.memory_capacity,
+      memoryUsed: row.memory_used,
+      predecessorId: row.predecessor_id,
+      isActive: row.is_active === 1,
+      createdAt: row.created_at,
+    };
+  },
+
+  getByCouncil(councilId: string): Agent[] {
+    const db = getDb();
+    const stmt = db.prepare('SELECT * FROM agents WHERE council_id = ? ORDER BY created_at DESC');
+    const rows = stmt.all(councilId) as any[];
+
+    return rows.map((row) => ({
+      id: row.id,
+      councilId: row.council_id,
+      name: row.name,
+      disposition: JSON.parse(row.disposition),
+      generation: row.generation,
+      memoryCapacity: row.memory_capacity,
+      memoryUsed: row.memory_used,
+      predecessorId: row.predecessor_id,
+      isActive: row.is_active === 1,
+      createdAt: row.created_at,
+    }));
+  },
+
+  getActiveByCouncil(councilId: string): Agent[] {
+    const db = getDb();
+    const stmt = db.prepare(
+      'SELECT * FROM agents WHERE council_id = ? AND is_active = 1 ORDER BY created_at DESC'
+    );
+    const rows = stmt.all(councilId) as any[];
+
+    return rows.map((row) => ({
+      id: row.id,
+      councilId: row.council_id,
+      name: row.name,
+      disposition: JSON.parse(row.disposition),
+      generation: row.generation,
+      memoryCapacity: row.memory_capacity,
+      memoryUsed: row.memory_used,
+      predecessorId: row.predecessor_id,
+      isActive: row.is_active === 1,
+      createdAt: row.created_at,
+    }));
+  },
+
+  update(id: string, updates: Partial<Agent>): boolean {
+    const db = getDb();
+    const fields: string[] = [];
+    const values: any[] = [];
+
+    if (updates.name !== undefined) {
+      fields.push('name = ?');
+      values.push(updates.name);
+    }
+    if (updates.disposition !== undefined) {
+      fields.push('disposition = ?');
+      values.push(JSON.stringify(updates.disposition));
+    }
+    if (updates.generation !== undefined) {
+      fields.push('generation = ?');
+      values.push(updates.generation);
+    }
+    if (updates.memoryCapacity !== undefined) {
+      fields.push('memory_capacity = ?');
+      values.push(updates.memoryCapacity);
+    }
+    if (updates.memoryUsed !== undefined) {
+      fields.push('memory_used = ?');
+      values.push(updates.memoryUsed);
+    }
+    if (updates.predecessorId !== undefined) {
+      fields.push('predecessor_id = ?');
+      values.push(updates.predecessorId || null);
+    }
+    if (updates.isActive !== undefined) {
+      fields.push('is_active = ?');
+      values.push(updates.isActive ? 1 : 0);
+    }
+
+    if (fields.length === 0) return false;
+
+    values.push(id);
+    const stmt = db.prepare(`UPDATE agents SET ${fields.join(', ')} WHERE id = ?`);
+    const result = stmt.run(...values);
+
+    return result.changes > 0;
+  },
+
+  delete(id: string): boolean {
+    const db = getDb();
+    const stmt = db.prepare('DELETE FROM agents WHERE id = ?');
+    const result = stmt.run(id);
+    return result.changes > 0;
+  },
+};
+
+export const memoryDb = {
+  insert(memory: Omit<Memory, 'id' | 'createdAt'>): Memory {
+    const db = getDb();
+    const id = generateId('memory');
+    const createdAt = Date.now();
+
+    const stmt = db.prepare(
+      'INSERT INTO memories (id, agent_id, content, disposition_score, source_type, source_ref, embedding_id, created_at) VALUES (?, ?, ?, ?, ?, ?, ?, ?)'
+    );
+    stmt.run(
+      id,
+      memory.agentId,
+      memory.content,
+      memory.dispositionScore,
+      memory.sourceType,
+      memory.sourceRef || null,
+      memory.embeddingId || null,
+      createdAt
+    );
+
+    return {
+      id,
+      agentId: memory.agentId,
+      content: memory.content,
+      dispositionScore: memory.dispositionScore,
+      sourceType: memory.sourceType,
+      sourceRef: memory.sourceRef,
+      embeddingId: memory.embeddingId,
+      createdAt,
+    };
+  },
+
+  getById(id: string): Memory | null {
+    const db = getDb();
+    const stmt = db.prepare('SELECT * FROM memories WHERE id = ?');
+    const row = stmt.get(id) as any;
+
+    if (!row) return null;
+
+    return {
+      id: row.id,
+      agentId: row.agent_id,
+      content: row.content,
+      dispositionScore: row.disposition_score,
+      sourceType: row.source_type,
+      sourceRef: row.source_ref,
+      embeddingId: row.embedding_id,
+      createdAt: row.created_at,
+    };
+  },
+
+  getByAgent(agentId: string): Memory[] {
+    const db = getDb();
+    const stmt = db.prepare('SELECT * FROM memories WHERE agent_id = ? ORDER BY created_at DESC');
+    const rows = stmt.all(agentId) as any[];
+
+    return rows.map((row) => ({
+      id: row.id,
+      agentId: row.agent_id,
+      content: row.content,
+      dispositionScore: row.disposition_score,
+      sourceType: row.source_type,
+      sourceRef: row.source_ref,
+      embeddingId: row.embedding_id,
+      createdAt: row.created_at,
+    }));
+  },
+
+  getLowestScoring(agentId: string): Memory | null {
+    const db = getDb();
+    const stmt = db.prepare(
+      'SELECT * FROM memories WHERE agent_id = ? ORDER BY disposition_score ASC LIMIT 1'
+    );
+    const row = stmt.get(agentId) as any;
+
+    if (!row) return null;
+
+    return {
+      id: row.id,
+      agentId: row.agent_id,
+      content: row.content,
+      dispositionScore: row.disposition_score,
+      sourceType: row.source_type,
+      sourceRef: row.source_ref,
+      embeddingId: row.embedding_id,
+      createdAt: row.created_at,
+    };
+  },
+
+  getTopByScore(agentId: string, limit: number): Memory[] {
+    const db = getDb();
+    const stmt = db.prepare(
+      'SELECT * FROM memories WHERE agent_id = ? ORDER BY disposition_score DESC LIMIT ?'
+    );
+    const rows = stmt.all(agentId, limit) as any[];
+
+    return rows.map((row) => ({
+      id: row.id,
+      agentId: row.agent_id,
+      content: row.content,
+      dispositionScore: row.disposition_score,
+      sourceType: row.source_type,
+      sourceRef: row.source_ref,
+      embeddingId: row.embedding_id,
+      createdAt: row.created_at,
+    }));
+  },
+
+  update(id: string, updates: Partial<Memory>): boolean {
+    const db = getDb();
+    const fields: string[] = [];
+    const values: any[] = [];
+
+    if (updates.content !== undefined) {
+      fields.push('content = ?');
+      values.push(updates.content);
+    }
+    if (updates.dispositionScore !== undefined) {
+      fields.push('disposition_score = ?');
+      values.push(updates.dispositionScore);
+    }
+    if (updates.sourceType !== undefined) {
+      fields.push('source_type = ?');
+      values.push(updates.sourceType);
+    }
+    if (updates.sourceRef !== undefined) {
+      fields.push('source_ref = ?');
+      values.push(updates.sourceRef || null);
+    }
+    if (updates.embeddingId !== undefined) {
+      fields.push('embedding_id = ?');
+      values.push(updates.embeddingId || null);
+    }
+
+    if (fields.length === 0) return false;
+
+    values.push(id);
+    const stmt = db.prepare(`UPDATE memories SET ${fields.join(', ')} WHERE id = ?`);
+    const result = stmt.run(...values);
+
+    return result.changes > 0;
+  },
+
+  delete(id: string): boolean {
+    const db = getDb();
+    const stmt = db.prepare('DELETE FROM memories WHERE id = ?');
+    const result = stmt.run(id);
+    return result.changes > 0;
+  },
+
+  countByAgent(agentId: string): number {
+    const db = getDb();
+    const stmt = db.prepare('SELECT COUNT(*) as count FROM memories WHERE agent_id = ?');
+    const row = stmt.get(agentId) as any;
+    return row.count;
+  },
+};
+
+export const generationDb = {
+  insert(generation: Omit<Generation, 'id' | 'createdAt'>): Generation {
+    const db = getDb();
+    const id = generateId('gen');
+    const createdAt = Date.now();
+
+    const stmt = db.prepare(
+      'INSERT INTO generations (id, agent_id, generation_num, seed_memories, disposition_snapshot, created_at) VALUES (?, ?, ?, ?, ?, ?)'
+    );
+    stmt.run(
+      id,
+      generation.agentId,
+      generation.generationNum,
+      generation.seedMemories ? JSON.stringify(generation.seedMemories) : null,
+      JSON.stringify(generation.dispositionSnapshot),
+      createdAt
+    );
+
+    return {
+      id,
+      agentId: generation.agentId,
+      generationNum: generation.generationNum,
+      seedMemories: generation.seedMemories,
+      dispositionSnapshot: generation.dispositionSnapshot,
+      createdAt,
+    };
+  },
+
+  getById(id: string): Generation | null {
+    const db = getDb();
+    const stmt = db.prepare('SELECT * FROM generations WHERE id = ?');
+    const row = stmt.get(id) as any;
+
+    if (!row) return null;
+
+    return {
+      id: row.id,
+      agentId: row.agent_id,
+      generationNum: row.generation_num,
+      seedMemories: row.seed_memories ? JSON.parse(row.seed_memories) : undefined,
+      dispositionSnapshot: JSON.parse(row.disposition_snapshot),
+      createdAt: row.created_at,
+      retiredAt: row.retired_at,
+    };
+  },
+
+  getByAgent(agentId: string): Generation[] {
+    const db = getDb();
+    const stmt = db.prepare(
+      'SELECT * FROM generations WHERE agent_id = ? ORDER BY generation_num DESC'
+    );
+    const rows = stmt.all(agentId) as any[];
+
+    return rows.map((row) => ({
+      id: row.id,
+      agentId: row.agent_id,
+      generationNum: row.generation_num,
+      seedMemories: row.seed_memories ? JSON.parse(row.seed_memories) : undefined,
+      dispositionSnapshot: JSON.parse(row.disposition_snapshot),
+      createdAt: row.created_at,
+      retiredAt: row.retired_at,
+    }));
+  },
+
+  getLatest(agentId: string): Generation | null {
+    const db = getDb();
+    const stmt = db.prepare(
+      'SELECT * FROM generations WHERE agent_id = ? ORDER BY generation_num DESC LIMIT 1'
+    );
+    const row = stmt.get(agentId) as any;
+
+    if (!row) return null;
+
+    return {
+      id: row.id,
+      agentId: row.agent_id,
+      generationNum: row.generation_num,
+      seedMemories: row.seed_memories ? JSON.parse(row.seed_memories) : undefined,
+      dispositionSnapshot: JSON.parse(row.disposition_snapshot),
+      createdAt: row.created_at,
+      retiredAt: row.retired_at,
+    };
+  },
+
+  update(id: string, updates: Partial<Generation>): boolean {
+    const db = getDb();
+    const fields: string[] = [];
+    const values: any[] = [];
+
+    if (updates.seedMemories !== undefined) {
+      fields.push('seed_memories = ?');
+      values.push(updates.seedMemories ? JSON.stringify(updates.seedMemories) : null);
+    }
+    if (updates.dispositionSnapshot !== undefined) {
+      fields.push('disposition_snapshot = ?');
+      values.push(JSON.stringify(updates.dispositionSnapshot));
+    }
+    if (updates.retiredAt !== undefined) {
+      fields.push('retired_at = ?');
+      values.push(updates.retiredAt || null);
+    }
+
+    if (fields.length === 0) return false;
+
+    values.push(id);
+    const stmt = db.prepare(`UPDATE generations SET ${fields.join(', ')} WHERE id = ?`);
+    const result = stmt.run(...values);
+
+    return result.changes > 0;
+  },
+};
+
+export const debateSessionDb = {
+  insert(session: Omit<DebateSession, 'id' | 'createdAt'>): DebateSession {
+    const db = getDb();
+    const id = generateId('session');
+    const createdAt = Date.now();
+
+    const stmt = db.prepare(
+      'INSERT INTO debate_sessions (id, council_id, user_prompt, phase, synthesis, created_at, completed_at) VALUES (?, ?, ?, ?, ?, ?, ?)'
+    );
+    stmt.run(
+      id,
+      session.councilId,
+      session.userPrompt,
+      session.phase,
+      session.synthesis || null,
+      createdAt,
+      session.completedAt || null
+    );
+
+    return {
+      id,
+      councilId: session.councilId,
+      userPrompt: session.userPrompt,
+      phase: session.phase,
+      synthesis: session.synthesis,
+      createdAt,
+      completedAt: session.completedAt,
+    };
+  },
+
+  getById(id: string): DebateSession | null {
+    const db = getDb();
+    const stmt = db.prepare('SELECT * FROM debate_sessions WHERE id = ?');
+    const row = stmt.get(id) as any;
+
+    if (!row) return null;
+
+    return {
+      id: row.id,
+      councilId: row.council_id,
+      userPrompt: row.user_prompt,
+      phase: row.phase,
+      synthesis: row.synthesis,
+      createdAt: row.created_at,
+      completedAt: row.completed_at,
+    };
+  },
+
+  getByCouncil(councilId: string): DebateSession[] {
+    const db = getDb();
+    const stmt = db.prepare(
+      'SELECT * FROM debate_sessions WHERE council_id = ? ORDER BY created_at DESC'
+    );
+    const rows = stmt.all(councilId) as any[];
+
+    return rows.map((row) => ({
+      id: row.id,
+      councilId: row.council_id,
+      userPrompt: row.user_prompt,
+      phase: row.phase,
+      synthesis: row.synthesis,
+      createdAt: row.created_at,
+      completedAt: row.completed_at,
+    }));
+  },
+
+  update(id: string, updates: Partial<DebateSession>): boolean {
+    const db = getDb();
+    const fields: string[] = [];
+    const values: any[] = [];
+
+    if (updates.phase !== undefined) {
+      fields.push('phase = ?');
+      values.push(updates.phase);
+    }
+    if (updates.synthesis !== undefined) {
+      fields.push('synthesis = ?');
+      values.push(updates.synthesis || null);
+    }
+    if (updates.completedAt !== undefined) {
+      fields.push('completed_at = ?');
+      values.push(updates.completedAt || null);
+    }
+
+    if (fields.length === 0) return false;
+
+    values.push(id);
+    const stmt = db.prepare(`UPDATE debate_sessions SET ${fields.join(', ')} WHERE id = ?`);
+    const result = stmt.run(...values);
+
+    return result.changes > 0;
+  },
+};
+
+export const debateTurnDb = {
+  insert(turn: Omit<DebateTurn, 'id' | 'createdAt'>): DebateTurn {
+    const db = getDb();
+    const id = generateId('turn');
+    const createdAt = Date.now();
+
+    const stmt = db.prepare(
+      'INSERT INTO debate_turns (id, session_id, agent_id, phase, content, created_at) VALUES (?, ?, ?, ?, ?, ?)'
+    );
+    stmt.run(id, turn.sessionId, turn.agentId, turn.phase, turn.content, createdAt);
+
+    return {
+      id,
+      sessionId: turn.sessionId,
+      agentId: turn.agentId,
+      phase: turn.phase,
+      content: turn.content,
+      createdAt,
+    };
+  },
+
+  getBySession(sessionId: string): DebateTurn[] {
+    const db = getDb();
+    const stmt = db.prepare(
+      'SELECT * FROM debate_turns WHERE session_id = ? ORDER BY created_at ASC'
+    );
+    const rows = stmt.all(sessionId) as any[];
+
+    return rows.map((row) => ({
+      id: row.id,
+      sessionId: row.session_id,
+      agentId: row.agent_id,
+      phase: row.phase,
+      content: row.content,
+      createdAt: row.created_at,
+    }));
+  },
+
+  getBySessionAndPhase(sessionId: string, phase: string): DebateTurn[] {
+    const db = getDb();
+    const stmt = db.prepare(
+      'SELECT * FROM debate_turns WHERE session_id = ? AND phase = ? ORDER BY created_at ASC'
+    );
+    const rows = stmt.all(sessionId, phase) as any[];
+
+    return rows.map((row) => ({
+      id: row.id,
+      sessionId: row.session_id,
+      agentId: row.agent_id,
+      phase: row.phase,
+      content: row.content,
+      createdAt: row.created_at,
+    }));
+  },
+};
+
+export const adoptionDb = {
+  insert(record: Omit<AdoptionRecord, 'id' | 'createdAt'>): AdoptionRecord {
+    const db = getDb();
+    const id = generateId('adoption');
+    const createdAt = Date.now();
+
+    const stmt = db.prepare(
+      'INSERT INTO adoption_history (id, agent_id, session_id, decision, user_feedback, disposition_delta, created_at) VALUES (?, ?, ?, ?, ?, ?, ?)'
+    );
+    stmt.run(
+      id,
+      record.agentId,
+      record.sessionId,
+      record.decision,
+      record.userFeedback || null,
+      record.dispositionDelta ? JSON.stringify(record.dispositionDelta) : null,
+      createdAt
+    );
+
+    return {
+      id,
+      agentId: record.agentId,
+      sessionId: record.sessionId,
+      decision: record.decision,
+      userFeedback: record.userFeedback,
+      dispositionDelta: record.dispositionDelta,
+      createdAt,
+    };
+  },
+
+  getByAgent(agentId: string): AdoptionRecord[] {
+    const db = getDb();
+    const stmt = db.prepare(
+      'SELECT * FROM adoption_history WHERE agent_id = ? ORDER BY created_at DESC'
+    );
+    const rows = stmt.all(agentId) as any[];
+
+    return rows.map((row) => ({
+      id: row.id,
+      agentId: row.agent_id,
+      sessionId: row.session_id,
+      decision: row.decision,
+      userFeedback: row.user_feedback,
+      dispositionDelta: row.disposition_delta ? JSON.parse(row.disposition_delta) : undefined,
+      createdAt: row.created_at,
+    }));
+  },
+
+  getBySession(sessionId: string): AdoptionRecord[] {
+    const db = getDb();
+    const stmt = db.prepare(
+      'SELECT * FROM adoption_history WHERE session_id = ? ORDER BY created_at DESC'
+    );
+    const rows = stmt.all(sessionId) as any[];
+
+    return rows.map((row) => ({
+      id: row.id,
+      agentId: row.agent_id,
+      sessionId: row.session_id,
+      decision: row.decision,
+      userFeedback: row.user_feedback,
+      dispositionDelta: row.disposition_delta ? JSON.parse(row.disposition_delta) : undefined,
+      createdAt: row.created_at,
+    }));
+  },
+};

--- a/src/council/storage/vector-store.test.ts
+++ b/src/council/storage/vector-store.test.ts
@@ -1,0 +1,193 @@
+import { describe, it, expect, beforeEach } from 'bun:test';
+import {
+  VectorStore,
+  VectorEntry,
+  SimilarityResult,
+  MockVectorStore,
+  createVectorStore,
+} from './vector-store';
+
+describe('VectorStore - Mock Implementation', () => {
+  let vectorStore: VectorStore;
+
+  beforeEach(async () => {
+    vectorStore = createVectorStore();
+    await vectorStore.clear();
+  });
+
+  describe('initialize()', () => {
+    it('should complete without error', async () => {
+      await expect(vectorStore.initialize()).resolves.toBeUndefined();
+    });
+  });
+
+  describe('addMemory()', () => {
+    it('should return an embedding ID', async () => {
+      const embeddingId = await vectorStore.addMemory(
+        'mem_1',
+        'agent_1',
+        'This is test content'
+      );
+
+      expect(embeddingId).toBeDefined();
+      expect(typeof embeddingId).toBe('string');
+      expect(embeddingId.startsWith('emb_')).toBe(true);
+    });
+
+    it('should store memory with correct agentId', async () => {
+      const embeddingId = await vectorStore.addMemory(
+        'mem_1',
+        'agent_1',
+        'Test content'
+      );
+
+      const results = await vectorStore.querySimilar('agent_1', 'Test', 10);
+      expect(results.length).toBeGreaterThan(0);
+      expect(results[0].memoryId).toBe(embeddingId);
+    });
+
+    it('should allow multiple memories per agent', async () => {
+      const id1 = await vectorStore.addMemory('mem_1', 'agent_1', 'First memory');
+      const id2 = await vectorStore.addMemory('mem_2', 'agent_1', 'Second memory');
+
+      expect(id1).not.toBe(id2);
+
+      const results = await vectorStore.querySimilar('agent_1', 'memory', 10);
+      expect(results.length).toBe(2);
+    });
+  });
+
+  describe('querySimilar()', () => {
+    beforeEach(async () => {
+      await vectorStore.addMemory('mem_1', 'agent_1', 'The quick brown fox jumps');
+      await vectorStore.addMemory('mem_2', 'agent_1', 'The lazy dog sleeps');
+      await vectorStore.addMemory('mem_3', 'agent_2', 'The quick brown fox runs');
+    });
+
+    it('should return results sorted by similarity (highest first)', async () => {
+      const results = await vectorStore.querySimilar('agent_1', 'quick fox', 10);
+
+      expect(results.length).toBeGreaterThan(0);
+      // First result should be more similar than second
+      if (results.length > 1) {
+        expect(results[0].similarity).toBeGreaterThanOrEqual(results[1].similarity);
+      }
+    });
+
+    it('should filter results by agentId', async () => {
+      const agent1Results = await vectorStore.querySimilar('agent_1', 'quick', 10);
+      const agent2Results = await vectorStore.querySimilar('agent_2', 'quick', 10);
+
+      expect(agent1Results.length).toBe(2);
+      expect(agent2Results.length).toBe(1);
+    });
+
+    it('should respect limit parameter', async () => {
+      const results = await vectorStore.querySimilar('agent_1', 'the', 1);
+      expect(results.length).toBe(1);
+
+      const allResults = await vectorStore.querySimilar('agent_1', 'the', 10);
+      expect(allResults.length).toBe(2);
+    });
+
+    it('should return empty array when no matches for agentId', async () => {
+      const results = await vectorStore.querySimilar('agent_999', 'quick', 10);
+      expect(results.length).toBe(0);
+    });
+
+    it('should calculate similarity based on keyword overlap', async () => {
+      // mem_1: "The quick brown fox jumps"
+      // mem_2: "The lazy dog sleeps"
+      // Query: "quick fox" should match mem_1 better than mem_2
+
+      const results = await vectorStore.querySimilar('agent_1', 'quick fox', 10);
+
+      expect(results.length).toBe(2);
+      expect(results[0].similarity).toBeGreaterThan(results[1].similarity);
+    });
+
+    it('should return similarity scores between 0 and 1', async () => {
+      const results = await vectorStore.querySimilar('agent_1', 'quick', 10);
+
+      results.forEach((result) => {
+        expect(result.similarity).toBeGreaterThanOrEqual(0);
+        expect(result.similarity).toBeLessThanOrEqual(1);
+      });
+    });
+  });
+
+  describe('deleteMemory()', () => {
+    it('should remove the entry', async () => {
+      const embeddingId = await vectorStore.addMemory(
+        'mem_1',
+        'agent_1',
+        'Test content'
+      );
+
+      let results = await vectorStore.querySimilar('agent_1', 'Test', 10);
+      expect(results.length).toBe(1);
+
+      await vectorStore.deleteMemory(embeddingId);
+
+      results = await vectorStore.querySimilar('agent_1', 'Test', 10);
+      expect(results.length).toBe(0);
+    });
+
+    it('should not affect other entries', async () => {
+      const id1 = await vectorStore.addMemory('mem_1', 'agent_1', 'First');
+      const id2 = await vectorStore.addMemory('mem_2', 'agent_1', 'Second');
+
+      await vectorStore.deleteMemory(id1);
+
+      const results = await vectorStore.querySimilar('agent_1', 'Second', 10);
+      expect(results.length).toBe(1);
+      expect(results[0].memoryId).toBe(id2);
+    });
+  });
+
+  describe('clear()', () => {
+    it('should remove all entries', async () => {
+      await vectorStore.addMemory('mem_1', 'agent_1', 'Content 1');
+      await vectorStore.addMemory('mem_2', 'agent_1', 'Content 2');
+      await vectorStore.addMemory('mem_3', 'agent_2', 'Content 3');
+
+      let results1 = await vectorStore.querySimilar('agent_1', 'Content', 10);
+      let results2 = await vectorStore.querySimilar('agent_2', 'Content', 10);
+      expect(results1.length + results2.length).toBe(3);
+
+      await vectorStore.clear();
+
+      results1 = await vectorStore.querySimilar('agent_1', 'Content', 10);
+      results2 = await vectorStore.querySimilar('agent_2', 'Content', 10);
+      expect(results1.length + results2.length).toBe(0);
+    });
+  });
+
+  describe('Similarity Scoring', () => {
+    it('should give higher scores to more similar content', async () => {
+      await vectorStore.addMemory('mem_1', 'agent_1', 'apple banana cherry');
+      await vectorStore.addMemory('mem_2', 'agent_1', 'apple banana date');
+      await vectorStore.addMemory('mem_3', 'agent_1', 'dog cat bird');
+
+      const results = await vectorStore.querySimilar('agent_1', 'apple banana', 10);
+
+      // Results should be sorted by similarity
+      expect(results[0].similarity).toBeGreaterThan(results[2].similarity);
+    });
+
+    it('should handle empty query gracefully', async () => {
+      await vectorStore.addMemory('mem_1', 'agent_1', 'test content');
+
+      const results = await vectorStore.querySimilar('agent_1', '', 10);
+      expect(Array.isArray(results)).toBe(true);
+    });
+
+    it('should handle single-word queries', async () => {
+      await vectorStore.addMemory('mem_1', 'agent_1', 'hello world');
+      await vectorStore.addMemory('mem_2', 'agent_1', 'goodbye world');
+
+      const results = await vectorStore.querySimilar('agent_1', 'hello', 10);
+      expect(results.length).toBeGreaterThan(0);
+    });
+  });
+});

--- a/src/council/storage/vector-store.ts
+++ b/src/council/storage/vector-store.ts
@@ -1,0 +1,83 @@
+export interface VectorStoreConfig {
+  type: 'mock' | 'chromadb';
+}
+
+export interface VectorEntry {
+  id: string;
+  agentId: string;
+  content: string;
+  embedding?: number[];
+}
+
+export interface SimilarityResult {
+  memoryId: string;
+  similarity: number;
+}
+
+export interface VectorStore {
+  initialize(): Promise<void>;
+  addMemory(memoryId: string, agentId: string, content: string): Promise<string>;
+  querySimilar(agentId: string, query: string, limit: number): Promise<SimilarityResult[]>;
+  deleteMemory(embeddingId: string): Promise<void>;
+  clear(): Promise<void>;
+}
+
+function calculateKeywordOverlap(text1: string, text2: string): number {
+  const words1 = new Set(
+    text1
+      .toLowerCase()
+      .split(/\s+/)
+      .filter((w) => w.length > 2)
+  );
+  const words2 = new Set(
+    text2
+      .toLowerCase()
+      .split(/\s+/)
+      .filter((w) => w.length > 2)
+  );
+
+  const intersection = new Set([...words1].filter((w) => words2.has(w)));
+  const union = new Set([...words1, ...words2]);
+
+  if (union.size === 0) return 0;
+  return intersection.size / union.size;
+}
+
+export class MockVectorStore implements VectorStore {
+  private entries: Map<string, VectorEntry> = new Map();
+
+  async initialize(): Promise<void> {
+    // No-op for mock
+  }
+
+  async addMemory(memoryId: string, agentId: string, content: string): Promise<string> {
+    const embeddingId = `emb_${Date.now()}_${Math.random().toString(36).substr(2, 9)}`;
+    this.entries.set(embeddingId, { id: embeddingId, agentId, content });
+    return embeddingId;
+  }
+
+  async querySimilar(agentId: string, query: string, limit: number): Promise<SimilarityResult[]> {
+    const agentEntries = Array.from(this.entries.values()).filter((e) => e.agentId === agentId);
+
+    const results = agentEntries.map((entry) => ({
+      memoryId: entry.id,
+      similarity: calculateKeywordOverlap(query, entry.content),
+    }));
+
+    return results.sort((a, b) => b.similarity - a.similarity).slice(0, limit);
+  }
+
+  async deleteMemory(embeddingId: string): Promise<void> {
+    this.entries.delete(embeddingId);
+  }
+
+  async clear(): Promise<void> {
+    this.entries.clear();
+  }
+}
+
+export function createVectorStore(config?: VectorStoreConfig): VectorStore {
+  return new MockVectorStore();
+}
+
+export const vectorStore = createVectorStore();

--- a/src/council/types.test.ts
+++ b/src/council/types.test.ts
@@ -1,0 +1,98 @@
+import { describe, it, expect } from 'bun:test';
+import {
+  isCouncilDomain,
+  isDebatePhase,
+  isMemorySourceType,
+} from './types';
+
+describe('Council Type Definitions', () => {
+  describe('Type Guards - CouncilDomain', () => {
+    it('should validate valid CouncilDomain values', () => {
+      expect(isCouncilDomain('lifestyle')).toBe(true);
+      expect(isCouncilDomain('creative')).toBe(true);
+      expect(isCouncilDomain('direction')).toBe(true);
+    });
+
+    it('should reject invalid CouncilDomain values', () => {
+      expect(isCouncilDomain('invalid')).toBe(false);
+      expect(isCouncilDomain('other')).toBe(false);
+      expect(isCouncilDomain(null)).toBe(false);
+      expect(isCouncilDomain(undefined)).toBe(false);
+      expect(isCouncilDomain(123)).toBe(false);
+    });
+  });
+
+  describe('Type Guards - DebatePhase', () => {
+    it('should validate valid DebatePhase values', () => {
+      expect(isDebatePhase('position')).toBe(true);
+      expect(isDebatePhase('challenge')).toBe(true);
+      expect(isDebatePhase('synthesis')).toBe(true);
+      expect(isDebatePhase('complete')).toBe(true);
+    });
+
+    it('should reject invalid DebatePhase values', () => {
+      expect(isDebatePhase('invalid')).toBe(false);
+      expect(isDebatePhase('start')).toBe(false);
+      expect(isDebatePhase(null)).toBe(false);
+      expect(isDebatePhase(undefined)).toBe(false);
+      expect(isDebatePhase(123)).toBe(false);
+    });
+  });
+
+  describe('Type Guards - MemorySourceType', () => {
+    it('should validate valid MemorySourceType values', () => {
+      expect(isMemorySourceType('debate')).toBe(true);
+      expect(isMemorySourceType('user_feedback')).toBe(true);
+      expect(isMemorySourceType('observation')).toBe(true);
+      expect(isMemorySourceType('seed')).toBe(true);
+    });
+
+    it('should reject invalid MemorySourceType values', () => {
+      expect(isMemorySourceType('invalid')).toBe(false);
+      expect(isMemorySourceType('feedback')).toBe(false);
+      expect(isMemorySourceType(null)).toBe(false);
+      expect(isMemorySourceType(undefined)).toBe(false);
+      expect(isMemorySourceType(123)).toBe(false);
+    });
+  });
+
+  describe('Type Guard Functions Export', () => {
+    it('should export type guard functions', () => {
+      expect(typeof isCouncilDomain).toBe('function');
+      expect(typeof isDebatePhase).toBe('function');
+      expect(typeof isMemorySourceType).toBe('function');
+    });
+
+    it('should have correct function signatures', () => {
+      expect(isCouncilDomain.length).toBe(1);
+      expect(isDebatePhase.length).toBe(1);
+      expect(isMemorySourceType.length).toBe(1);
+    });
+  });
+
+  describe('Type Guard Edge Cases', () => {
+    it('should handle empty strings', () => {
+      expect(isCouncilDomain('')).toBe(false);
+      expect(isDebatePhase('')).toBe(false);
+      expect(isMemorySourceType('')).toBe(false);
+    });
+
+    it('should handle objects', () => {
+      expect(isCouncilDomain({})).toBe(false);
+      expect(isDebatePhase({})).toBe(false);
+      expect(isMemorySourceType({})).toBe(false);
+    });
+
+    it('should handle arrays', () => {
+      expect(isCouncilDomain([])).toBe(false);
+      expect(isDebatePhase([])).toBe(false);
+      expect(isMemorySourceType([])).toBe(false);
+    });
+
+    it('should be case-sensitive', () => {
+      expect(isCouncilDomain('LIFESTYLE')).toBe(false);
+      expect(isDebatePhase('POSITION')).toBe(false);
+      expect(isMemorySourceType('DEBATE')).toBe(false);
+    });
+  });
+});

--- a/src/council/types.ts
+++ b/src/council/types.ts
@@ -367,6 +367,36 @@ export interface SuccessionEvent {
 }
 
 // ============================================================================
+// Vector Store Interfaces
+// ============================================================================
+
+/**
+ * Result from vector store similarity query
+ */
+export interface SimilarityResult {
+  /** ID of the memory */
+  memoryId: string;
+  /** Similarity score (0-1) */
+  similarity: number;
+}
+
+/**
+ * Vector store for semantic memory retrieval
+ */
+export interface VectorStore {
+  /** Initialize the vector store */
+  initialize(): Promise<void>;
+  /** Add a memory to the vector store */
+  addMemory(memoryId: string, agentId: string, content: string): Promise<string>;
+  /** Query for similar memories */
+  querySimilar(agentId: string, query: string, limit: number): Promise<SimilarityResult[]>;
+  /** Delete a memory from the vector store */
+  deleteMemory(embeddingId: string): Promise<void>;
+  /** Clear all memories from the vector store */
+  clear(): Promise<void>;
+}
+
+// ============================================================================
 // Type Guards
 // ============================================================================
 

--- a/src/council/types.ts
+++ b/src/council/types.ts
@@ -1,0 +1,402 @@
+/**
+ * Council Type Definitions
+ * Core types for the Agent Council system
+ */
+
+// ============================================================================
+// Type Literals
+// ============================================================================
+
+/**
+ * Domains that councils can operate in
+ */
+export type CouncilDomain = 'lifestyle' | 'creative' | 'direction';
+
+/**
+ * Phases of a debate session
+ */
+export type DebatePhase = 'position' | 'challenge' | 'synthesis' | 'complete';
+
+/**
+ * Sources of memory creation
+ */
+export type MemorySourceType = 'debate' | 'user_feedback' | 'observation' | 'seed';
+
+// ============================================================================
+// Core Entity Interfaces
+// ============================================================================
+
+/**
+ * Represents a Council - a group of agents discussing a specific domain
+ */
+export interface Council {
+  /** Unique identifier for the council */
+  id: string;
+  /** Human-readable name */
+  name: string;
+  /** Domain this council operates in */
+  domain: CouncilDomain;
+  /** Optional description of the council's purpose */
+  description?: string;
+  /** Timestamp of creation (milliseconds) */
+  createdAt: number;
+}
+
+/**
+ * Represents an Agent's disposition - their perspective, priorities, and voice
+ */
+export interface AgentDisposition {
+  /** Core orientation/philosophy of the agent */
+  orientation: string;
+  /** Criteria for filtering and evaluating information */
+  filterCriteria: {
+    /** Keywords this agent focuses on */
+    keywords: string[];
+    /** Sentiment bias: positive, negative, or neutral */
+    sentimentBias: 'positive' | 'negative' | 'neutral';
+    /** Preference for novel vs. proven approaches */
+    noveltyPreference: 'high' | 'low' | 'balanced';
+    /** Tolerance for risk and uncertainty */
+    riskTolerance: 'high' | 'low' | 'moderate';
+  };
+  /** Weighted priorities for decision-making (sum should be ~1.0) */
+  priorities: {
+    /** Weight for cost considerations */
+    cost: number;
+    /** Weight for quality considerations */
+    quality: number;
+    /** Weight for novelty/innovation */
+    novelty: number;
+    /** Weight for reliability/proven methods */
+    reliability: number;
+  };
+  /** How the agent communicates */
+  voice: {
+    /** Tone of communication */
+    tone: string;
+    /** Preferred vocabulary and phrases */
+    vocabulary: string[];
+  };
+}
+
+/**
+ * Represents an Agent - a participant in council debates
+ */
+export interface Agent {
+  /** Unique identifier for the agent */
+  id: string;
+  /** ID of the council this agent belongs to */
+  councilId: string;
+  /** Human-readable name */
+  name: string;
+  /** The agent's disposition and perspective */
+  disposition: AgentDisposition;
+  /** Current generation number (increments on succession) */
+  generation: number;
+  /** Maximum memories this agent can store */
+  memoryCapacity: number;
+  /** Current number of memories stored */
+  memoryUsed: number;
+  /** ID of the agent this one succeeded (if applicable) */
+  predecessorId?: string;
+  /** Whether this agent is currently active */
+  isActive: boolean;
+  /** Timestamp of creation (milliseconds) */
+  createdAt: number;
+}
+
+/**
+ * Represents a Memory - a stored insight or observation
+ */
+export interface Memory {
+  /** Unique identifier for the memory */
+  id: string;
+  /** ID of the agent that owns this memory */
+  agentId: string;
+  /** The memory content */
+  content: string;
+  /** Score indicating how well this aligns with agent disposition (0-1) */
+  dispositionScore: number;
+  /** Source of this memory */
+  sourceType: MemorySourceType;
+  /** Reference to the source (e.g., session ID, feedback ID) */
+  sourceRef?: string;
+  /** ID of the embedding vector (if stored in vector DB) */
+  embeddingId?: string;
+  /** Timestamp of creation (milliseconds) */
+  createdAt: number;
+}
+
+/**
+ * Represents a Generation - a snapshot of an agent at a point in time
+ */
+export interface Generation {
+  /** Unique identifier for this generation */
+  id: string;
+  /** ID of the agent this generation belongs to */
+  agentId: string;
+  /** Generation number */
+  generationNum: number;
+  /** Memory IDs used as seeds for this generation */
+  seedMemories?: string[];
+  /** Snapshot of the agent's disposition at this generation */
+  dispositionSnapshot: AgentDisposition;
+  /** Timestamp of creation (milliseconds) */
+  createdAt: number;
+  /** Timestamp when this generation was retired (if applicable) */
+  retiredAt?: number;
+}
+
+/**
+ * Represents a Debate Session - a structured discussion among agents
+ */
+export interface DebateSession {
+  /** Unique identifier for the session */
+  id: string;
+  /** ID of the council conducting this debate */
+  councilId: string;
+  /** The user's prompt that initiated the debate */
+  userPrompt: string;
+  /** Current phase of the debate */
+  phase: DebatePhase;
+  /** Synthesized conclusion (populated in synthesis phase) */
+  synthesis?: string;
+  /** Timestamp of creation (milliseconds) */
+  createdAt: number;
+  /** Timestamp when debate completed (if applicable) */
+  completedAt?: number;
+}
+
+/**
+ * Represents a Turn in a Debate - one agent's contribution
+ */
+export interface DebateTurn {
+  /** Unique identifier for this turn */
+  id: string;
+  /** ID of the session this turn belongs to */
+  sessionId: string;
+  /** ID of the agent making this turn */
+  agentId: string;
+  /** Phase this turn belongs to */
+  phase: 'position' | 'challenge';
+  /** The agent's contribution */
+  content: string;
+  /** Timestamp of creation (milliseconds) */
+  createdAt: number;
+}
+
+/**
+ * Represents an Adoption Record - user feedback on a debate outcome
+ */
+export interface AdoptionRecord {
+  /** Unique identifier for this record */
+  id: string;
+  /** ID of the agent whose position was evaluated */
+  agentId: string;
+  /** ID of the session this feedback relates to */
+  sessionId: string;
+  /** Whether the user adopted, rejected, or partially adopted the position */
+  decision: 'adopted' | 'rejected' | 'partial';
+  /** Optional user feedback text */
+  userFeedback?: string;
+  /** Changes to the agent's disposition based on feedback */
+  dispositionDelta?: Partial<AgentDisposition>;
+  /** Timestamp of creation (milliseconds) */
+  createdAt: number;
+}
+
+// ============================================================================
+// Configuration Interfaces
+// ============================================================================
+
+/**
+ * Configuration for initializing councils
+ */
+export interface CouncilConfig {
+  /** Array of council definitions */
+  councils: CouncilDefinition[];
+}
+
+/**
+ * Definition of a council to be created
+ */
+export interface CouncilDefinition {
+  /** Domain this council operates in */
+  domain: CouncilDomain;
+  /** Name of the council */
+  name: string;
+  /** Description of the council's purpose */
+  description: string;
+  /** Agents to initialize in this council */
+  agents: AgentDefinition[];
+}
+
+/**
+ * Definition of an agent to be created
+ */
+export interface AgentDefinition {
+  /** Name of the agent */
+  name: string;
+  /** The agent's disposition */
+  disposition: AgentDisposition;
+  /** Optional memory capacity (defaults to 100) */
+  memoryCapacity?: number;
+}
+
+// ============================================================================
+// Debate Protocol Interfaces
+// ============================================================================
+
+/**
+ * Request to initiate a debate
+ */
+export interface DebateRequest {
+  /** The prompt/question to debate */
+  prompt: string;
+  /** Optional council domain to use (defaults to first available) */
+  council?: CouncilDomain;
+  /** Optional debate configuration */
+  options?: DebateOptions;
+}
+
+/**
+ * Options for configuring a debate
+ */
+export interface DebateOptions {
+  /** Whether to include predecessor agents in the debate */
+  includeAncestors?: boolean;
+  /** Maximum number of debate rounds */
+  maxRounds?: number;
+  /** Whether to include verbose output */
+  verbose?: boolean;
+}
+
+/**
+ * Result of a completed debate
+ */
+export interface DebateResult {
+  /** ID of the debate session */
+  sessionId: string;
+  /** Domain of the council that debated */
+  council: CouncilDomain;
+  /** Phases of the debate with contributions */
+  phases: {
+    /** Positions taken by agents */
+    positions: AgentPosition[];
+    /** Challenges raised during debate */
+    challenges: AgentChallenge[];
+    /** Synthesized conclusion */
+    synthesis: string;
+  };
+  /** Overall recommendation from the council */
+  recommendation: string;
+  /** Confidence level in the recommendation (0-1) */
+  confidence: number;
+  /** Number of memories created during this debate */
+  memoriesCreated: number;
+}
+
+/**
+ * An agent's position in a debate
+ */
+export interface AgentPosition {
+  /** ID of the agent */
+  agentId: string;
+  /** Name of the agent */
+  agentName: string;
+  /** The position statement */
+  position: string;
+  /** Key points supporting the position */
+  keyPoints: string[];
+  /** IDs of memories relevant to this position */
+  relevantMemories: string[];
+}
+
+/**
+ * A challenge raised during debate
+ */
+export interface AgentChallenge {
+  /** ID of the agent raising the challenge */
+  challengerId: string;
+  /** Name of the challenging agent */
+  challengerName: string;
+  /** ID of the agent being challenged */
+  targetId: string;
+  /** Name of the target agent */
+  targetName: string;
+  /** The challenge statement */
+  challenge: string;
+  /** Counter-points to the target's position */
+  counterPoints: string[];
+}
+
+// ============================================================================
+// Memory Management Interfaces
+// ============================================================================
+
+/**
+ * Evaluation of whether a memory should be stored
+ */
+export interface MemoryEvaluation {
+  /** The memory content being evaluated */
+  content: string;
+  /** Score indicating disposition alignment (0-1) */
+  dispositionScore: number;
+  /** Whether this memory should be stored */
+  shouldStore: boolean;
+  /** ID of a memory that could be displaced if needed */
+  displacementCandidate?: string;
+  /** Reasoning for the evaluation decision */
+  reasoning: string;
+}
+
+/**
+ * Event representing agent succession
+ */
+export interface SuccessionEvent {
+  /** ID of the predecessor agent */
+  predecessorId: string;
+  /** ID of the successor agent */
+  successorId: string;
+  /** Generation number of the successor */
+  generationNum: number;
+  /** Memory IDs passed to the successor */
+  seedMemories: string[];
+  /** Disposition inherited by the successor */
+  inheritedDisposition: AgentDisposition;
+}
+
+// ============================================================================
+// Type Guards
+// ============================================================================
+
+/**
+ * Type guard for CouncilDomain
+ */
+export function isCouncilDomain(value: unknown): value is CouncilDomain {
+  return value === 'lifestyle' || value === 'creative' || value === 'direction';
+}
+
+/**
+ * Type guard for DebatePhase
+ */
+export function isDebatePhase(value: unknown): value is DebatePhase {
+  return (
+    value === 'position' ||
+    value === 'challenge' ||
+    value === 'synthesis' ||
+    value === 'complete'
+  );
+}
+
+/**
+ * Type guard for MemorySourceType
+ */
+export function isMemorySourceType(value: unknown): value is MemorySourceType {
+  return (
+    value === 'debate' ||
+    value === 'user_feedback' ||
+    value === 'observation' ||
+    value === 'seed'
+  );
+}


### PR DESCRIPTION
## Summary

Implements a multi-agent council system where 12 agents develop distinctive "taste" through disposition-based memory forgetting.

- **3 Councils**: Lifestyle (4 agents), Creative (4 agents), Direction (4 agents)
- **Memory Forgetting**: When memory fills, lowest-scoring memories are displaced
- **Generational Succession**: Agents spawn successors with seed memories
- **Debate Protocol**: Position → Challenge → Synthesis phases

## Test Results

**250 tests passing** across 11 test files with TDD workflow.

## Implementation (11 commits)

| Wave | Components | Tests |
|------|------------|-------|
| Wave 1 | Types, Schema, Agent Configs | 78 |
| Wave 2 | Storage, Vector Store, Scoring | 76 |
| Wave 3 | Memory Manager, Generation Manager, Router | 44 |
| Wave 4 | Debate Engine, Plugin Integration | 52 |

## Files Added

```
src/council/
├── types.ts                    # All interfaces
├── db.ts                       # SQLite schema (7 tables)
├── index.ts                    # Main entry point
├── config/councils.ts          # 12 agent dispositions
├── storage/
│   ├── council-db.ts           # CRUD operations
│   └── vector-store.ts         # Mock vector store
├── scoring/disposition-scorer.ts
├── memory/memory-manager.ts    # Forgetting algorithm
├── generation/generation-manager.ts  # Succession
├── router/council-router.ts    # Domain classification
└── debate/debate-engine.ts     # Position/Challenge/Synthesis
```

## Usage

```typescript
import { runCouncil, formatDebateResult } from './council';

const result = await runCouncil({
  prompt: "Should I try the new ramen place?",
  council: 'lifestyle',  // optional, auto-detected
});

console.log(formatDebateResult(result));
```

## Closes #4